### PR TITLE
Add checksum generation back for grader report

### DIFF
--- a/roles/ftl_run_grade_report_generation/tasks/main.yml
+++ b/roles/ftl_run_grade_report_generation/tasks/main.yml
@@ -21,6 +21,17 @@
     student_errors: "{{ r_lab_pass.found }}"
     report_status_message:  SUCCESS
 
+- name: Get report hash
+  stat:
+    path: "{{ grader_working_dir }}/{{ grader_student_report_file }}"
+    checksum_algorithm: sha256
+  register: st
+
+- name: Sign student report
+  lineinfile:
+    path: "{{ grader_working_dir }}/{{ grader_student_report_file }}"
+    line: "{{ st.stat.checksum }}  {{ grader_student_report_file }}"
+
 - name: Output lab status and error count
   debug:
     msg: 


### PR DESCRIPTION
This section was removed at some point, but we rely on the checksum value to grade homework in OCP4 Advanced Deployment today. This needs to be added back in to ensure that the file is not changed between generation during the FTL grading and submission to the LMS.

Whether this is needed in the future with more automated grading can be decided later - either way, having one extra line in the file with the checksum shouldn't hurt.

@tonykay Please make sure adding this extra line in the grading report won't affect any integration work with the LMS

@pavelanni Please make sure this being added back in is what we need to grade the homework today.

cc @wkulhanek 