### PR TITLE
fix whitespaces that can confuse the checksummer

### DIFF
--- a/courses/ocp4_advanced_deployment/lab_hw/grade_lab.yml
+++ b/courses/ocp4_advanced_deployment/lab_hw/grade_lab.yml
@@ -42,19 +42,19 @@
       name: grader_check_ocp_pod_node
     vars:
       node_label: node-role.kubernetes.io/infra=
-      pod_label: docker-registry=default 
+      pod_label: docker-registry=default
       task_description_message: Check if image registry is running on infra nodes
       student_error_message: "The image registry is not running on infra nodes"
-      
+
   - name: Check if cluster monitoring is running on infra nodes
     include_role:
       name: grader_check_ocp_pod_node
     vars:
       node_label: node-role.kubernetes.io/infra=
-      pod_label: app=prometheus 
+      pod_label: app=prometheus
       task_description_message: Check if cluster monitoring is running on infra nodes
       student_error_message: "Cluster monitoring is not running on infra nodes"
-    
+
   - name: Check if Elasticsearch is running on infra nodes
     include_role:
       name: grader_check_ocp_pod_node
@@ -63,7 +63,7 @@
       pod_label: component=elasticsearch
       task_description_message: Check if Elasticsearch is running on infra nodes
       student_error_message: "Elasticsearch is not running on infra nodes"
-    
+
   - name: Check if the CPU request is 500m for Elasticsearch
     include_role:
       name: grader_check_ocp_resource
@@ -111,7 +111,7 @@
       name: grader_check_ocp_pod_label
     vars:
       pod_label: ingresscontroller.operator.openshift.io/deployment-ingresscontroller=default
-      pod_count: 2 
+      pod_count: 2
       task_description_message: Check if the cluster has 2 router pods
       student_error_message: "The cluster doesn't have 2 router pods"
 
@@ -123,7 +123,6 @@
       pod_label: ingresscontroller.operator.openshift.io/deployment-ingresscontroller=default
       task_description_message: Check if the routers are running on infra nodes
       student_error_message: "The routers are not running on infra nodes"
-      
 
   - name: Check if 5 user identities exist
     include_role:
@@ -241,7 +240,7 @@
       task_description_message: Check NetworkPolicy allow-from-openshift-ingress in project george-test
       student_error_message: "NetworkPolicy allow-from-openshift-ingress doesn't exist in project george-test"
 
-  - name: Delete project george-test 
+  - name: Delete project george-test
     command: oc delete project george-test
     ignore_errors: yes
 

--- a/roles/ftl_run_grade_report_generation/tasks/main.yml
+++ b/roles/ftl_run_grade_report_generation/tasks/main.yml
@@ -34,9 +34,9 @@
 
 - name: Output lab status and error count
   debug:
-    msg: 
+    msg:
       - "lab_passed = {{ lab_passed }}"
-      - "Error count = {{ student_errors }}"  
+      - "Error count = {{ student_errors }}"
     verbosity: 2
 
 - name: Finalize lab report with status

--- a/roles/ftl_run_log_grade_to_log/tasks/main.yml
+++ b/roles/ftl_run_log_grade_to_log/tasks/main.yml
@@ -18,6 +18,6 @@
         create: yes
         insertafter: EOF
         path: "{{ grader_working_dir }}/{{ grader_student_report_file }}"
-        line: "{{ '%-6s %-30s %-50s' | format(grader_log_prefix, inventory_hostname, student_log_message) }}"
+        line: "{{ '%-6s %-30s %-s' | format(grader_log_prefix, inventory_hostname, student_log_message) }}"
   delegate_to: localhost
 ...


### PR DESCRIPTION
Prevents trailing whitespace in grading_report.txt

The FTL grader process creates trailing whitespace for some messages. the ansible jinja2 template {{ '%-50s", variable }} is to blame for short messages.  The FTL checksum creator includes that whitespace.

Sometimes students copy/paste their grading_report.txt to a local file and then upload that to the LMS.  The whitespace does not match, and the checksum fails.

This prevents the trailing whitespace from being created.

Also cleans up some rando whitespace in other files.