### PR TITLE
OCP 4.5 disco osp solver

### DIFF
--- a/courses/ocp4_advanced_deployment/lab_03_1/solve_lab.yml
+++ b/courses/ocp4_advanced_deployment/lab_03_1/solve_lab.yml
@@ -1,4 +1,20 @@
 ---
+- name: Check Solver Prereqs
+  hosts: localhost
+  gather_facts: false
+  become: false
+  tasks:
+    - name: Check for presence of $HOME/ocp_pullsecret.json
+      stat:
+        path: $HOME/ocp_pullsecret.json
+      register: r_pullsecret_stat
+    
+    - name: assert presence of ocp_pullsecret.json
+      assert:
+        that:
+          - r_pullsecret_stat.stat.exists
+        fail_msg: "You must have your pull secret from Red Hat to install OpenShift."
+
 - name: Run reset_lab
   import_playbook: reset_lab.yml
 
@@ -12,13 +28,13 @@
     OCP_RELEASE: "{{ ocp_version }}"
 
   tasks:
-    - name: Set OCP version
+    - name: Set OCP version in bashrc
       lineinfile:
         path: $HOME/.bashrc
         regexp: "^export OCP_RELEASE"
         line: "export OCP_RELEASE={{ ocp_version }}"
 
-    - name: Get oc binary
+    - name: Install oc binary
       unarchive:
         src: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OCP_RELEASE/openshift-client-linux-$OCP_RELEASE.tar.gz
         dest: /usr/local/sbin
@@ -543,9 +559,29 @@
       retries: 20
       delay: 30
       until: r_pvcs.resources | length == 1
+      # TODO is this really ready?
       environment:
         KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
       # tags: test_csv
+
+ # oc patch configs.imageregistry.operator.openshift.io cluster --type merge --patch '{"spec":{"storage":{"emptyDir":{}}}}'
+ # oc patch configs.imageregistry.operator.openshift.io cluster --type json --patch '[{ "op": "remove", "path": "/spec/storage/pvc" }, { "op": "add", "path": "/spec/storage/emptydir", "value": "{}" }]'
+
+    - name: patch registry to scale to 0
+      shell: >-
+        oc patch configs.imageregistry.operator.openshift.io cluster --type json --patch 
+        '[{ "op": "replace", "path": "/spec/replicas", "value": 0}]'
+      environment:
+        KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
+
+#    - name: patch registry to use emptydir, scale to 0
+#      shell: >-
+#        oc patch configs.imageregistry.operator.openshift.io cluster --type json --patch 
+#        '[{ "op": "remove", "path": "/spec/storage/pvc" }, 
+#          { "op": "add", "path": "/spec/storage/emptydir", "value": "{}" },
+#          { "op": "replace", "path": "/spec/replicas", "value": 0}]'
+#      environment:
+#        KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
 
     - name: Delete registry PVC on cinder
       k8s:
@@ -556,23 +592,23 @@
         namespace: openshift-image-registry
       tags: test_csv
 
-    - name: Get registry pod info
-      k8s_facts:
-        kind: Pod
-        namespace: openshift-image-registry
-        label_selectors:
-          - docker-registry=default
-      register: r_pods
-      tags: test_csv
-
-    - name: Delete registry pod to free PVC
-      k8s:
-        state: absent
-        api_version: v1
-        kind: Pod
-        namespace: "openshift-image-registry"
-        name: "{{ r_pods.resources[0].metadata.name }}"
-      tags: test_csv
+#    - name: Get registry pod info
+#      k8s_facts:
+#        kind: Pod
+#        namespace: openshift-image-registry
+#        label_selectors:
+#          - docker-registry=default
+#      register: r_pods
+#      tags: test_csv
+#
+#    - name: Delete registry pod to free PVC
+#      k8s:
+#        state: absent
+#        api_version: v1
+#        kind: Pod
+#        namespace: "openshift-image-registry"
+#        name: "{{ r_pods.resources[0].metadata.name }}"
+#      tags: test_csv
 
     - name: Wait until PVC is gone
       k8s_facts:

--- a/courses/ocp4_advanced_deployment/lab_03_1/solve_lab.yml
+++ b/courses/ocp4_advanced_deployment/lab_03_1/solve_lab.yml
@@ -23,7 +23,7 @@
   gather_facts: false
   become: false
   vars:
-    ocp_version: 4.4.3
+    ocp_version: 4.5.3
   environment:
     OCP_RELEASE: "{{ ocp_version }}"
 
@@ -168,8 +168,8 @@
   gather_facts: false
   become: false
   vars:
-    ocp_version: 4.4.3
-    rhcos_image_version: "rhcos-ocp44"
+    ocp_version: 4.5.3
+    rhcos_image_version: "rhcos-ocp45"
   environment:
     OCP_RELEASE: "{{ ocp_version }}"
     LOCAL_REGISTRY: "utilityvm.example.com:5000"
@@ -479,7 +479,7 @@
         validate_certs: false
       register: r_bootstrap_csr
       retries: 20
-      delay: 30
+      delay: 60
       until: r_bootstrap_csr.resources | to_json | from_json | json_query(bootstrap_csr_query) | length >= 2
       vars:
         bootstrap_csr_query: >-
@@ -562,7 +562,7 @@
       # TODO is this really ready?
       environment:
         KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
-      # tags: test_csv
+      tags: test_csv
 
  # oc patch configs.imageregistry.operator.openshift.io cluster --type merge --patch '{"spec":{"storage":{"emptyDir":{}}}}'
  # oc patch configs.imageregistry.operator.openshift.io cluster --type json --patch '[{ "op": "remove", "path": "/spec/storage/pvc" }, { "op": "add", "path": "/spec/storage/emptydir", "value": "{}" }]'
@@ -573,6 +573,7 @@
         '[{ "op": "replace", "path": "/spec/replicas", "value": 0}]'
       environment:
         KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
+      tags: test_csv
 
 #    - name: patch registry to use emptydir, scale to 0
 #      shell: >-
@@ -584,13 +585,21 @@
 #        KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
 
     - name: Delete registry PVC on cinder
-      k8s:
-        state: absent
-        api_version: v1
-        kind: PersistentVolumeClaim
-        name: image-registry-storage
-        namespace: openshift-image-registry
-      tags: test_csv
+      shell: >-
+        oc delete pvc --all -n openshift-image-registry
+      environment:
+        KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
+
+
+#    - name: Delete registry PVC on cinder
+#      k8s:
+#        state: absent
+#        api_version: v1
+#        kind: PersistentVolumeClaim
+#        name: image-registry-storage
+#        namespace: openshift-image-registry
+#      register: r_pvc_delete
+#      tags: test_csv
 
 #    - name: Get registry pod info
 #      k8s_facts:

--- a/courses/ocp4_advanced_deployment/lab_03_1/solve_lab.yml
+++ b/courses/ocp4_advanced_deployment/lab_03_1/solve_lab.yml
@@ -7,7 +7,7 @@
   gather_facts: false
   become: false
   vars:
-    ocp_version: 4.3.13
+    ocp_version: 4.4.3
   environment:
     OCP_RELEASE: "{{ ocp_version }}"
 
@@ -152,7 +152,8 @@
   gather_facts: false
   become: false
   vars:
-    ocp_version: 4.3.13
+    ocp_version: 4.4.3
+    rhcos_image_version: "rhcos-ocp44"
   environment:
     OCP_RELEASE: "{{ ocp_version }}"
     LOCAL_REGISTRY: "utilityvm.example.com:5000"
@@ -224,7 +225,7 @@
 
     - name: Verify that images are present and pullable
       podman_image:
-        name: utilityvm.example.com:5000/ocp4/openshift4:4.3.13-operator-lifecycle-manager
+        name: "utilityvm.example.com:5000/ocp4/openshift4:${OCP_RELEASE}-operator-lifecycle-manager"
         auth_file: "$HOME/merged_pullsecret.json"
 
     - name: Check release info to make sure it works
@@ -383,7 +384,7 @@
 
     - name: Create bootstrap server
       shell: >-
-        /usr/local/bin/openstack server create --image rhcos-ocp43 --flavor 4c16g30d --user-data "$HOME/openstack-upi/$INFRA_ID-bootstrap-ignition.json"
+        /usr/local/bin/openstack server create --image {{ rhcos_image_version }} --flavor 4c16g30d --user-data "$HOME/openstack-upi/$INFRA_ID-bootstrap-ignition.json"
         --port "$INFRA_ID-bootstrap-port" --wait --property openshiftClusterID="$INFRA_ID" "$INFRA_ID-bootstrap"
       environment:
         INFRA_ID: "{{ r_infra_id.stdout }}"
@@ -405,7 +406,7 @@
     - name: Create master servers
       shell: >-
         for index in $(seq 0 2); do
-        /usr/local/bin/openstack server create --boot-from-volume 30 --image rhcos-ocp43 --flavor 4c16g30d
+        /usr/local/bin/openstack server create --boot-from-volume 30 --image {{ rhcos_image_version }} --flavor 4c16g30d
         --user-data "$HOME/openstack-upi/$INFRA_ID-master-$index-ignition.json" --port "$INFRA_ID-master-port-$index"
         --property openshiftClusterID="$INFRA_ID" "$INFRA_ID-master-$index";
         done
@@ -448,7 +449,7 @@
     - name: Add worker servers
       shell: >-
         for index in $(seq 0 1); do
-        /usr/local/bin/openstack server create --image rhcos-ocp43 --flavor 4c16g30d --user-data "$HOME/openstack-upi/worker.ign"
+        /usr/local/bin/openstack server create --image {{ rhcos_image_version }} --flavor 4c16g30d --user-data "$HOME/openstack-upi/worker.ign"
         --port "$INFRA_ID-worker-port-$index" --property openshiftClusterID="$INFRA_ID" "$INFRA_ID-worker-$index";
         done
       environment:
@@ -523,6 +524,22 @@
       assert:
         that: r_nodes.stdout_lines | length == 2
 
+    - name: Delete registry PVC on cinder
+      k8s:
+        state: absent
+        api_version: v1
+        kind: PersistentVolumeClaim
+        name: "image-registry-storage"
+
+
+    - name: Delete registry pod to free PVC
+      k8s:
+        state: absent
+        api_version: v1
+        kind: Pod
+      
+
+
     - name: Create registry PV
       k8s:
         state: present
@@ -538,6 +555,8 @@
       environment:
         KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
       tags: test
+
+    #- name: Scale up registry
 
     - name: Wait for registry CO to become available
       k8s_facts:

--- a/courses/ocp4_advanced_deployment/lab_03_1/solve_lab.yml
+++ b/courses/ocp4_advanced_deployment/lab_03_1/solve_lab.yml
@@ -536,16 +536,40 @@
         state: absent
         api_version: v1
         kind: PersistentVolumeClaim
-        name: "image-registry-storage"
+        name: image-registry-storage
+        namespace: openshift-image-registry
+      tags: test_csv
 
+    - name: Get registry pod info
+      k8s_facts:
+        kind: Pod
+        namespace: openshift-image-registry
+        label_selectors:
+          - docker-registry=default
+      register: r_pods
+      tags: test_csv
 
     - name: Delete registry pod to free PVC
       k8s:
         state: absent
         api_version: v1
         kind: Pod
-      
+        namespace: "openshift-image-registry"
+        name: "{{ r_pods.resources[0].metadata.name }}"
+      tags: test_csv
 
+
+#    - name: Wait until PVC is gone
+#      k8s_facts:
+#        kind: PersistentVolumeClaim
+#        namespace: openshift-image-registry
+#      register: r_pvcs
+#      retries: 20
+#      delay: 30
+#      until: r_pvc.resources | to_json | from_json | length == 0
+#      environment:
+#        KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
+#      tags: test_csv
 
     - name: Create registry PV
       k8s:
@@ -563,29 +587,10 @@
         KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
       tags: test_csv
 
-    #- name: Scale up registry
-
-    - name: Wait for registry CO to become available
-      k8s_facts:
-        api_version: imageregistry.operator.openshift.io/v1
-        name: cluster
-        kind: Config
-      register: r_image_registry
-      vars:
-        registry_available: >-
-          {{ r_image_registry.resources[0].status.conditions | json_query(registry_query) }}
-        registry_query: >-
-          [?type=='Progressing'][].status|[0]
-      until: registry_available | bool
-      retries: 30
-      delay: 30
-      environment:
-        KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
-
-    - name: Patch registry for new storage
+    - name: Patch registry to scale to two pods
       shell: >-
         /usr/local/sbin/oc patch configs.imageregistry.operator.openshift.io cluster --type=json -p
-        '[{"op": "replace", "path": "/spec/storage", "value": {"pvc": {"claim": "image-registry-storage"}}}]'
+        '[{"op": "replace", "path": "/spec/replicas", "value": 2}]'
       environment:
         KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
       tags: test_csv

--- a/courses/ocp4_advanced_deployment/lab_03_1/solve_lab.yml
+++ b/courses/ocp4_advanced_deployment/lab_03_1/solve_lab.yml
@@ -165,7 +165,7 @@
   tasks:
     - set_fact:
         ansible_python_interpreter: /usr/bin/python3
-      tags: test
+      tags: test_prep
 
         
     - name: Copy certificate from utility VM
@@ -464,28 +464,28 @@
       register: r_bootstrap_csr
       retries: 20
       delay: 30
-      until: r_bootstrap_csr.resources | json_query(bootstrap_csr_query) | length >= 2
+      until: r_bootstrap_csr.resources | to_json | from_json | json_query(bootstrap_csr_query) | length >= 2
       vars:
         bootstrap_csr_query: >-
-          [?!(status) && contains(spec.username, 'bootstrap')]
+          [?!(status) && contains(spec.username, `bootstrap`)] | []
       environment:
         KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
-      #tags: csr_check
+      tags: bootstrap_csr_check
 
     - name: dump r_bootstrap_csr
       debug:
         var: r_bootstrap_csr
-      #tags: csr_check
+      tags: bootstrap_csr_check
 
     - name: Approve pending bootstrap CSRs
       shell: /usr/local/sbin/oc adm certificate approve {{ item }}
       environment:
         KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
-      loop: "{{ r_bootstrap_csr.resources | json_query(bootstrap_pending_query) }}"
+      loop: "{{ r_bootstrap_csr.resources | to_json | from_json | json_query(bootstrap_pending_query) }}"
       vars:
         bootstrap_pending_query: >-
-          [?!(status)]
-      #tags: csr_check
+          [?!(status) && contains(spec.username, `bootstrap`)].metadata.name
+      tags: bootstrap_csr_check
 
     - name: Get current node CSRs (10m max)
       k8s_facts:
@@ -498,15 +498,15 @@
       until: r_node_csr.resources | to_json | from_json | json_query(node_csr_query) | length >= 2
       vars:
         node_csr_query: >-
-          [?contains(spec.username, 'worker')]
+          [?!(status) && contains(spec.username, `worker`)] | []
       environment:
         KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
-      tags: csr_check
+      tags: node_csr_check
 
     - name: dump r_node_csr
       debug:
         var: r_node_csr
-      tags: csr_check
+      tags: node_csr_check
 
     - name: Approve pending node CSRs
       shell: /usr/local/sbin/oc adm certificate approve {{ item }}
@@ -516,10 +516,7 @@
       vars:
         node_pending_query: >-
           [?!(status) && contains(spec.username, 'worker')].metadata.name
-          
-         
-         
-          #[?!(status) && contains(spec.username, 'worker')].metadata.name
+      tags: node_csr_check
 
     - pause:
         seconds: 15
@@ -556,7 +553,7 @@
         src: "{{ lookup('env', 'HOME') }}/resources/pv-registry.yaml"
       environment:
         KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
-      tags: test
+      tags: test_csv
 
     - name: Create registry PVC
       k8s:
@@ -564,7 +561,7 @@
         src: "$HOME/resources/pvc-registry.yaml"
       environment:
         KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
-      tags: test
+      tags: test_csv
 
     #- name: Scale up registry
 
@@ -591,8 +588,8 @@
         '[{"op": "replace", "path": "/spec/storage", "value": {"pvc": {"claim": "image-registry-storage"}}}]'
       environment:
         KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
-      tags: test
+      tags: test_csv
 
     - name: Finish installation
       shell: /usr/local/sbin/openshift-install wait-for install-complete --dir $HOME/openstack-upi
-      tags: test
+      tags: test_csv

--- a/courses/ocp4_advanced_deployment/lab_03_1/solve_lab.yml
+++ b/courses/ocp4_advanced_deployment/lab_03_1/solve_lab.yml
@@ -531,6 +531,22 @@
       assert:
         that: r_nodes.stdout_lines | length == 2
 
+#
+## Switch Image Registry from PVC RWO Cinder to PVC RWX NFS
+#
+
+    - name: Wait until wrong PVC exists as installed by the installer
+      k8s_facts:
+        kind: PersistentVolumeClaim
+        namespace: openshift-image-registry
+      register: r_pvcs
+      retries: 20
+      delay: 30
+      until: r_pvcs.resources | length == 1
+      environment:
+        KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
+      # tags: test_csv
+
     - name: Delete registry PVC on cinder
       k8s:
         state: absent
@@ -558,18 +574,17 @@
         name: "{{ r_pods.resources[0].metadata.name }}"
       tags: test_csv
 
-
-#    - name: Wait until PVC is gone
-#      k8s_facts:
-#        kind: PersistentVolumeClaim
-#        namespace: openshift-image-registry
-#      register: r_pvcs
-#      retries: 20
-#      delay: 30
-#      until: r_pvc.resources | to_json | from_json | length == 0
-#      environment:
-#        KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
-#      tags: test_csv
+    - name: Wait until PVC is gone
+      k8s_facts:
+        kind: PersistentVolumeClaim
+        namespace: openshift-image-registry
+      register: r_pvcs
+      retries: 20
+      delay: 30
+      until: r_pvcs.resources | length == 0
+      environment:
+        KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
+      tags: test_csv
 
     - name: Create registry PV
       k8s:
@@ -597,4 +612,4 @@
 
     - name: Finish installation
       shell: /usr/local/sbin/openshift-install wait-for install-complete --dir $HOME/openstack-upi
-      tags: test_csv
+      #tags: test_csv

--- a/courses/ocp4_advanced_deployment/lab_03_1/solve_lab.yml
+++ b/courses/ocp4_advanced_deployment/lab_03_1/solve_lab.yml
@@ -166,6 +166,7 @@
     - set_fact:
         ansible_python_interpreter: /usr/bin/python3
       tags: test
+
         
     - name: Copy certificate from utility VM
       command: scp utilityvm.example.com:/opt/registry/certs/domain.crt /etc/pki/ca-trust/source/anchors/
@@ -466,13 +467,15 @@
       until: r_bootstrap_csr.resources | json_query(bootstrap_csr_query) | length >= 2
       vars:
         bootstrap_csr_query: >-
-          [?!(status.conditions)]
+          [?!(status) && contains(spec.username, 'bootstrap')]
       environment:
         KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
+      #tags: csr_check
 
     - name: dump r_bootstrap_csr
       debug:
         var: r_bootstrap_csr
+      #tags: csr_check
 
     - name: Approve pending bootstrap CSRs
       shell: /usr/local/sbin/oc adm certificate approve {{ item }}
@@ -481,7 +484,8 @@
       loop: "{{ r_bootstrap_csr.resources | json_query(bootstrap_pending_query) }}"
       vars:
         bootstrap_pending_query: >-
-          [?!(status.conditions)].metadata.name
+          [?!(status)]
+      #tags: csr_check
 
     - name: Get current node CSRs (10m max)
       k8s_facts:
@@ -494,13 +498,15 @@
       until: r_node_csr.resources | to_json | from_json | json_query(node_csr_query) | length >= 2
       vars:
         node_csr_query: >-
-          [?!(status.conditions) && contains(spec.username, 'worker')]
+          [?contains(spec.username, 'worker')]
       environment:
         KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
+      tags: csr_check
 
     - name: dump r_node_csr
       debug:
         var: r_node_csr
+      tags: csr_check
 
     - name: Approve pending node CSRs
       shell: /usr/local/sbin/oc adm certificate approve {{ item }}
@@ -509,7 +515,11 @@
       loop: "{{ r_node_csr.resources | to_json | from_json | json_query(node_pending_query) }}"
       vars:
         node_pending_query: >-
-          [?!(status.conditions) && contains(spec.username, 'worker')].metadata.name
+          [?!(status) && contains(spec.username, 'worker')].metadata.name
+          
+         
+         
+          #[?!(status) && contains(spec.username, 'worker')].metadata.name
 
     - pause:
         seconds: 15


### PR DESCRIPTION
* updated ocp_version to 4.5.3
* uploaded and updated OpenStack image to rhcos-ocp45
* increased timeout for compute node bootstrap CSR approval

Brought forward from 4.4 solver:

* check for prereq files (fail early)
* CSRs now formatted differently
  * Update jmsepath to detect `status: {}` for unapproved CSRs.
* openshift-installer/openshift-image-registry operator now creates cinder volume for image registry, RWO - refactor
  * scale registry to 0 replicas
  * replace PV and PVC with NFS backing store RWX
  * scale registry to 2 replicas