### PR TITLE
4.6 solver install

### DIFF
--- a/courses/ocp4_advanced_deployment/lab_03_1aws/files/aws_upi_bootstrap_template.yaml
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/files/aws_upi_bootstrap_template.yaml
@@ -1,0 +1,211 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Template for OpenShift Cluster Bootstrap (EC2 Instance, Security Groups and IAM)
+
+Parameters:
+  InfrastructureName:
+    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
+    MaxLength: 27
+    MinLength: 1
+    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
+    Description: A short, unique cluster ID used to tag cloud resources and identify items owned or used by the cluster.
+    Type: String
+  RhcosAmi:
+    Description: Current Red Hat Enterprise Linux CoreOS AMI to use for bootstrap.
+    Type: AWS::EC2::Image::Id
+  AllowedBootstrapSshCidr:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|1[0-9]|2[0-9]|3[0-2]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/0-32.
+    Default: 0.0.0.0/0
+    Description: CIDR block to allow SSH access to the bootstrap node.
+    Type: String
+  PublicSubnet:
+    Description: The public subnet to launch the bootstrap node into.
+    Type: AWS::EC2::Subnet::Id
+  MasterSecurityGroupId:
+    Description: The master security group ID for registering temporary rules.
+    Type: AWS::EC2::SecurityGroup::Id
+  VpcId:
+    Description: The VPC-scoped resources will belong to this VPC.
+    Type: AWS::EC2::VPC::Id
+  BootstrapIgnitionLocation:
+    Default: s3://my-s3-bucket/bootstrap.ign
+    Description: Ignition config file location.
+    Type: String
+  AutoRegisterELB:
+    Default: "yes"
+    AllowedValues:
+    - "yes"
+    - "no"
+    Description: Do you want to invoke NLB registration, which requires a Lambda ARN parameter?
+    Type: String
+  RegisterNlbIpTargetsLambdaArn:
+    Description: ARN for NLB IP target registration lambda.
+    Type: String
+  ExternalApiTargetGroupArn:
+    Description: ARN for external API load balancer target group.
+    Type: String
+  InternalApiTargetGroupArn:
+    Description: ARN for internal API load balancer target group.
+    Type: String
+  InternalServiceTargetGroupArn:
+    Description: ARN for internal service load balancer target group.
+    Type: String
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+    - Label:
+        default: "Cluster Information"
+      Parameters:
+      - InfrastructureName
+    - Label:
+        default: "Host Information"
+      Parameters:
+      - RhcosAmi
+      - BootstrapIgnitionLocation
+      - MasterSecurityGroupId
+    - Label:
+        default: "Network Configuration"
+      Parameters:
+      - VpcId
+      - AllowedBootstrapSshCidr
+      - PublicSubnet
+    - Label:
+        default: "Load Balancer Automation"
+      Parameters:
+      - AutoRegisterELB
+      - RegisterNlbIpTargetsLambdaArn
+      - ExternalApiTargetGroupArn
+      - InternalApiTargetGroupArn
+      - InternalServiceTargetGroupArn
+    ParameterLabels:
+      InfrastructureName:
+        default: "Infrastructure Name"
+      VpcId:
+        default: "VPC ID"
+      AllowedBootstrapSshCidr:
+        default: "Allowed SSH Source"
+      PublicSubnet:
+        default: "Public Subnet"
+      RhcosAmi:
+        default: "Red Hat Enterprise Linux CoreOS AMI ID"
+      BootstrapIgnitionLocation:
+        default: "Bootstrap Ignition Source"
+      MasterSecurityGroupId:
+        default: "Master Security Group ID"
+      AutoRegisterELB:
+        default: "Use Provided ELB Automation"
+
+Conditions:
+  DoRegistration: !Equals ["yes", !Ref AutoRegisterELB]
+
+Resources:
+  BootstrapIamRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        - Effect: "Allow"
+          Principal:
+            Service:
+            - "ec2.amazonaws.com"
+          Action:
+          - "sts:AssumeRole"
+      Path: "/"
+      Policies:
+      - PolicyName: !Join ["-", [!Ref InfrastructureName, "bootstrap", "policy"]]
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: "Allow"
+            Action: "ec2:Describe*"
+            Resource: "*"
+          - Effect: "Allow"
+            Action: "ec2:AttachVolume"
+            Resource: "*"
+          - Effect: "Allow"
+            Action: "ec2:DetachVolume"
+            Resource: "*"
+          - Effect: "Allow"
+            Action: "s3:GetObject"
+            Resource: "*"
+
+  BootstrapInstanceProfile:
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      Path: "/"
+      Roles:
+      - Ref: "BootstrapIamRole"
+
+  BootstrapSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Cluster Bootstrap Security Group
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: 22
+        ToPort: 22
+        CidrIp: !Ref AllowedBootstrapSshCidr
+      - IpProtocol: tcp
+        ToPort: 19531
+        FromPort: 19531
+        CidrIp: 0.0.0.0/0
+      VpcId: !Ref VpcId
+
+  BootstrapInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref RhcosAmi
+      IamInstanceProfile: !Ref BootstrapInstanceProfile
+      InstanceType: "i3.large"
+      NetworkInterfaces:
+      - AssociatePublicIpAddress: "true"
+        DeviceIndex: "0"
+        GroupSet:
+        - !Ref "BootstrapSecurityGroup"
+        - !Ref "MasterSecurityGroupId"
+        SubnetId: !Ref "PublicSubnet"
+      UserData:
+        Fn::Base64: !Sub
+        - '{"ignition":{"config":{"replace":{"source":"${S3Loc}"}},"version":"3.1.0"}}'
+        - {
+          S3Loc: !Ref BootstrapIgnitionLocation
+        }
+
+  RegisterBootstrapApiTarget:
+    Condition: DoRegistration
+    Type: Custom::NLBRegister
+    Properties:
+      ServiceToken: !Ref RegisterNlbIpTargetsLambdaArn
+      TargetArn: !Ref ExternalApiTargetGroupArn
+      TargetIp: !GetAtt BootstrapInstance.PrivateIp
+
+  RegisterBootstrapInternalApiTarget:
+    Condition: DoRegistration
+    Type: Custom::NLBRegister
+    Properties:
+      ServiceToken: !Ref RegisterNlbIpTargetsLambdaArn
+      TargetArn: !Ref InternalApiTargetGroupArn
+      TargetIp: !GetAtt BootstrapInstance.PrivateIp
+
+  RegisterBootstrapInternalServiceTarget:
+    Condition: DoRegistration
+    Type: Custom::NLBRegister
+    Properties:
+      ServiceToken: !Ref RegisterNlbIpTargetsLambdaArn
+      TargetArn: !Ref InternalServiceTargetGroupArn
+      TargetIp: !GetAtt BootstrapInstance.PrivateIp
+
+Outputs:
+  BootstrapInstanceId:
+    Description: Bootstrap Instance ID.
+    Value: !Ref BootstrapInstance
+
+  BootstrapPublicIp:
+    Description: The bootstrap node public IP address.
+    Value: !GetAtt BootstrapInstance.PublicIp
+
+  BootstrapPrivateIp:
+    Description: The bootstrap node private IP address.
+    Value: !GetAtt BootstrapInstance.PrivateIp

--- a/courses/ocp4_advanced_deployment/lab_03_1aws/files/aws_upi_control_plane_template.yaml
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/files/aws_upi_control_plane_template.yaml
@@ -1,0 +1,388 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Template for OpenShift Cluster Node Launch (EC2 master instances)
+
+Parameters:
+  InfrastructureName:
+    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
+    MaxLength: 27
+    MinLength: 1
+    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
+    Description: A short, unique cluster ID used to tag nodes for the kubelet cloud provider.
+    Type: String
+  RhcosAmi:
+    Description: Current Red Hat Enterprise Linux CoreOS AMI to use for bootstrap.
+    Type: AWS::EC2::Image::Id
+  AutoRegisterDNS:
+    Default: "yes"
+    AllowedValues:
+    - "yes"
+    - "no"
+    Description: Do you want to invoke DNS etcd registration, which requires Hosted Zone information?
+    Type: String
+  PrivateHostedZoneId:
+    Description: The Route53 private zone ID to register the etcd targets with, such as Z21IXYZABCZ2A4.
+    Type: String
+  PrivateHostedZoneName:
+    Description: The Route53 zone to register the targets with, such as cluster.example.com. Omit the trailing period.
+    Type: String
+  Master0Subnet:
+    Description: The subnets, recommend private, to launch the master nodes into.
+    Type: AWS::EC2::Subnet::Id
+  Master1Subnet:
+    Description: The subnets, recommend private, to launch the master nodes into.
+    Type: AWS::EC2::Subnet::Id
+  Master2Subnet:
+    Description: The subnets, recommend private, to launch the master nodes into.
+    Type: AWS::EC2::Subnet::Id
+  MasterSecurityGroupId:
+    Description: The master security group ID to associate with master nodes.
+    Type: AWS::EC2::SecurityGroup::Id
+  IgnitionLocation:
+    Default: https://api-int.$CLUSTER_NAME.$DOMAIN:22623/config/master
+    Description: Ignition config file location.
+    Type: String
+  CertificateAuthorities:
+    Default: data:text/plain;charset=utf-8;base64,ABC...xYz==
+    Description: Base64 encoded certificate authority string to use.
+    Type: String
+  MasterInstanceProfileName:
+    Description: IAM profile to associate with master nodes.
+    Type: String
+  MasterInstanceType:
+    Default: m5.xlarge
+    Type: String
+    AllowedValues:
+    - "m4.xlarge"
+    - "m4.2xlarge"
+    - "m4.4xlarge"
+    - "m4.8xlarge"
+    - "m4.10xlarge"
+    - "m4.16xlarge"
+    - "m5.xlarge"
+    - "m5.2xlarge"
+    - "m5.4xlarge"
+    - "m5.8xlarge"
+    - "m5.10xlarge"
+    - "m5.16xlarge"
+    - "c4.2xlarge"
+    - "c4.4xlarge"
+    - "c4.8xlarge"
+    - "r4.xlarge"
+    - "r4.2xlarge"
+    - "r4.4xlarge"
+    - "r4.8xlarge"
+    - "r4.16xlarge"
+  AutoRegisterELB:
+    Default: "yes"
+    AllowedValues:
+    - "yes"
+    - "no"
+    Description: Do you want to invoke NLB registration, which requires a Lambda ARN parameter?
+    Type: String
+  RegisterNlbIpTargetsLambdaArn:
+    Description: ARN for NLB IP target registration lambda. Supply the value from the cluster infrastructure or select "no" for AutoRegisterELB.
+    Type: String
+  ExternalApiTargetGroupArn:
+    Description: ARN for external API load balancer target group. Supply the value from the cluster infrastructure or select "no" for AutoRegisterELB.
+    Type: String
+  InternalApiTargetGroupArn:
+    Description: ARN for internal API load balancer target group. Supply the value from the cluster infrastructure or select "no" for AutoRegisterELB.
+    Type: String
+  InternalServiceTargetGroupArn:
+    Description: ARN for internal service load balancer target group. Supply the value from the cluster infrastructure or select "no" for AutoRegisterELB.
+    Type: String
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+    - Label:
+        default: "Cluster Information"
+      Parameters:
+      - InfrastructureName
+    - Label:
+        default: "Host Information"
+      Parameters:
+      - MasterInstanceType
+      - RhcosAmi
+      - IgnitionLocation
+      - CertificateAuthorities
+      - MasterSecurityGroupId
+      - MasterInstanceProfileName
+    - Label:
+        default: "Network Configuration"
+      Parameters:
+      - VpcId
+      - AllowedBootstrapSshCidr
+      - Master0Subnet
+      - Master1Subnet
+      - Master2Subnet
+    - Label:
+        default: "DNS"
+      Parameters:
+      - AutoRegisterDNS
+      - PrivateHostedZoneName
+      - PrivateHostedZoneId
+    - Label:
+        default: "Load Balancer Automation"
+      Parameters:
+      - AutoRegisterELB
+      - RegisterNlbIpTargetsLambdaArn
+      - ExternalApiTargetGroupArn
+      - InternalApiTargetGroupArn
+      - InternalServiceTargetGroupArn
+    ParameterLabels:
+      InfrastructureName:
+        default: "Infrastructure Name"
+      VpcId:
+        default: "VPC ID"
+      Master0Subnet:
+        default: "Master-0 Subnet"
+      Master1Subnet:
+        default: "Master-1 Subnet"
+      Master2Subnet:
+        default: "Master-2 Subnet"
+      MasterInstanceType:
+        default: "Master Instance Type"
+      MasterInstanceProfileName:
+        default: "Master Instance Profile Name"
+      RhcosAmi:
+        default: "Red Hat Enterprise Linux CoreOS AMI ID"
+      BootstrapIgnitionLocation:
+        default: "Master Ignition Source"
+      CertificateAuthorities:
+        default: "Ignition CA String"
+      MasterSecurityGroupId:
+        default: "Master Security Group ID"
+      AutoRegisterDNS:
+        default: "Use Provided DNS Automation"
+      AutoRegisterELB:
+        default: "Use Provided ELB Automation"
+      PrivateHostedZoneName:
+        default: "Private Hosted Zone Name"
+      PrivateHostedZoneId:
+        default: "Private Hosted Zone ID"
+
+Conditions:
+  DoRegistration: !Equals ["yes", !Ref AutoRegisterELB]
+  DoDns: !Equals ["yes", !Ref AutoRegisterDNS]
+
+Resources:
+  Master0:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref RhcosAmi
+      BlockDeviceMappings:
+      - DeviceName: /dev/xvda
+        Ebs:
+          VolumeSize: "120"
+          VolumeType: "gp2"
+      IamInstanceProfile: !Ref MasterInstanceProfileName
+      InstanceType: !Ref MasterInstanceType
+      NetworkInterfaces:
+      - AssociatePublicIpAddress: "false"
+        DeviceIndex: "0"
+        GroupSet:
+        - !Ref "MasterSecurityGroupId"
+        SubnetId: !Ref "Master0Subnet"
+      UserData:
+        Fn::Base64: !Sub
+        - '{"ignition":{"config":{"merge":[{"source":"${SOURCE}"}]},"security":{"tls":{"certificateAuthorities":[{"source":"${CA_BUNDLE}"}]}},"version":"3.1.0"}}'
+        - {
+          SOURCE: !Ref IgnitionLocation,
+          CA_BUNDLE: !Ref CertificateAuthorities,
+        }
+      Tags:
+      - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
+        Value: "shared"
+
+  RegisterMaster0:
+    Condition: DoRegistration
+    Type: Custom::NLBRegister
+    Properties:
+      ServiceToken: !Ref RegisterNlbIpTargetsLambdaArn
+      TargetArn: !Ref ExternalApiTargetGroupArn
+      TargetIp: !GetAtt Master0.PrivateIp
+
+  RegisterMaster0InternalApiTarget:
+    Condition: DoRegistration
+    Type: Custom::NLBRegister
+    Properties:
+      ServiceToken: !Ref RegisterNlbIpTargetsLambdaArn
+      TargetArn: !Ref InternalApiTargetGroupArn
+      TargetIp: !GetAtt Master0.PrivateIp
+
+  RegisterMaster0InternalServiceTarget:
+    Condition: DoRegistration
+    Type: Custom::NLBRegister
+    Properties:
+      ServiceToken: !Ref RegisterNlbIpTargetsLambdaArn
+      TargetArn: !Ref InternalServiceTargetGroupArn
+      TargetIp: !GetAtt Master0.PrivateIp
+
+  Master1:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref RhcosAmi
+      BlockDeviceMappings:
+      - DeviceName: /dev/xvda
+        Ebs:
+          VolumeSize: "120"
+          VolumeType: "gp2"
+      IamInstanceProfile: !Ref MasterInstanceProfileName
+      InstanceType: !Ref MasterInstanceType
+      NetworkInterfaces:
+      - AssociatePublicIpAddress: "false"
+        DeviceIndex: "0"
+        GroupSet:
+        - !Ref "MasterSecurityGroupId"
+        SubnetId: !Ref "Master1Subnet"
+      UserData:
+        Fn::Base64: !Sub
+        - '{"ignition":{"config":{"merge":[{"source":"${SOURCE}"}]},"security":{"tls":{"certificateAuthorities":[{"source":"${CA_BUNDLE}"}]}},"version":"3.1.0"}}'
+        - {
+          SOURCE: !Ref IgnitionLocation,
+          CA_BUNDLE: !Ref CertificateAuthorities,
+        }
+      Tags:
+      - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
+        Value: "shared"
+
+  RegisterMaster1:
+    Condition: DoRegistration
+    Type: Custom::NLBRegister
+    Properties:
+      ServiceToken: !Ref RegisterNlbIpTargetsLambdaArn
+      TargetArn: !Ref ExternalApiTargetGroupArn
+      TargetIp: !GetAtt Master1.PrivateIp
+
+  RegisterMaster1InternalApiTarget:
+    Condition: DoRegistration
+    Type: Custom::NLBRegister
+    Properties:
+      ServiceToken: !Ref RegisterNlbIpTargetsLambdaArn
+      TargetArn: !Ref InternalApiTargetGroupArn
+      TargetIp: !GetAtt Master1.PrivateIp
+
+  RegisterMaster1InternalServiceTarget:
+    Condition: DoRegistration
+    Type: Custom::NLBRegister
+    Properties:
+      ServiceToken: !Ref RegisterNlbIpTargetsLambdaArn
+      TargetArn: !Ref InternalServiceTargetGroupArn
+      TargetIp: !GetAtt Master1.PrivateIp
+
+  Master2:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref RhcosAmi
+      BlockDeviceMappings:
+      - DeviceName: /dev/xvda
+        Ebs:
+          VolumeSize: "120"
+          VolumeType: "gp2"
+      IamInstanceProfile: !Ref MasterInstanceProfileName
+      InstanceType: !Ref MasterInstanceType
+      NetworkInterfaces:
+      - AssociatePublicIpAddress: "false"
+        DeviceIndex: "0"
+        GroupSet:
+        - !Ref "MasterSecurityGroupId"
+        SubnetId: !Ref "Master2Subnet"
+      UserData:
+        Fn::Base64: !Sub
+        - '{"ignition":{"config":{"merge":[{"source":"${SOURCE}"}]},"security":{"tls":{"certificateAuthorities":[{"source":"${CA_BUNDLE}"}]}},"version":"3.1.0"}}'
+        - {
+          SOURCE: !Ref IgnitionLocation,
+          CA_BUNDLE: !Ref CertificateAuthorities,
+        }
+      Tags:
+      - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
+        Value: "shared"
+
+  RegisterMaster2:
+    Condition: DoRegistration
+    Type: Custom::NLBRegister
+    Properties:
+      ServiceToken: !Ref RegisterNlbIpTargetsLambdaArn
+      TargetArn: !Ref ExternalApiTargetGroupArn
+      TargetIp: !GetAtt Master2.PrivateIp
+
+  RegisterMaster2InternalApiTarget:
+    Condition: DoRegistration
+    Type: Custom::NLBRegister
+    Properties:
+      ServiceToken: !Ref RegisterNlbIpTargetsLambdaArn
+      TargetArn: !Ref InternalApiTargetGroupArn
+      TargetIp: !GetAtt Master2.PrivateIp
+
+  RegisterMaster2InternalServiceTarget:
+    Condition: DoRegistration
+    Type: Custom::NLBRegister
+    Properties:
+      ServiceToken: !Ref RegisterNlbIpTargetsLambdaArn
+      TargetArn: !Ref InternalServiceTargetGroupArn
+      TargetIp: !GetAtt Master2.PrivateIp
+
+  EtcdSrvRecords:
+    Condition: DoDns
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref PrivateHostedZoneId
+      Name: !Join [".", ["_etcd-server-ssl._tcp", !Ref PrivateHostedZoneName]]
+      ResourceRecords:
+      - !Join [
+        " ",
+        ["0 10 2380", !Join [".", ["etcd-0", !Ref PrivateHostedZoneName]]],
+      ]
+      - !Join [
+        " ",
+        ["0 10 2380", !Join [".", ["etcd-1", !Ref PrivateHostedZoneName]]],
+      ]
+      - !Join [
+        " ",
+        ["0 10 2380", !Join [".", ["etcd-2", !Ref PrivateHostedZoneName]]],
+      ]
+      TTL: 60
+      Type: SRV
+
+  Etcd0Record:
+    Condition: DoDns
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref PrivateHostedZoneId
+      Name: !Join [".", ["etcd-0", !Ref PrivateHostedZoneName]]
+      ResourceRecords:
+      - !GetAtt Master0.PrivateIp
+      TTL: 60
+      Type: A
+
+  Etcd1Record:
+    Condition: DoDns
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref PrivateHostedZoneId
+      Name: !Join [".", ["etcd-1", !Ref PrivateHostedZoneName]]
+      ResourceRecords:
+      - !GetAtt Master1.PrivateIp
+      TTL: 60
+      Type: A
+
+  Etcd2Record:
+    Condition: DoDns
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref PrivateHostedZoneId
+      Name: !Join [".", ["etcd-2", !Ref PrivateHostedZoneName]]
+      ResourceRecords:
+      - !GetAtt Master2.PrivateIp
+      TTL: 60
+      Type: A
+
+Outputs:
+  PrivateIPs:
+    Description: The control-plane node private IP addresses.
+    Value:
+      !Join [
+        ",",
+        [!GetAtt Master0.PrivateIp, !GetAtt Master1.PrivateIp, !GetAtt Master2.PrivateIp]
+      ]

--- a/courses/ocp4_advanced_deployment/lab_03_1aws/files/aws_upi_route53_template.yaml
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/files/aws_upi_route53_template.yaml
@@ -1,0 +1,398 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Template for OpenShift Cluster Network Elements (Route53 & LBs)
+
+Parameters:
+  ClusterName:
+    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
+    MaxLength: 27
+    MinLength: 1
+    ConstraintDescription: Cluster name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
+    Description: A short, representative cluster name to use for host names and other identifying names.
+    Type: String
+  InfrastructureName:
+    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
+    MaxLength: 27
+    MinLength: 1
+    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
+    Description: A short, unique cluster ID used to tag cloud resources and identify items owned or used by the cluster.
+    Type: String
+  HostedZoneId:
+    Description: The Route53 public zone ID to register the targets with, such as Z21IXYZABCZ2A4.
+    Type: String
+  HostedZoneName:
+    Description: The Route53 zone to register the targets with, such as example.com. Omit the trailing period.
+    Type: String
+    Default: "example.com"
+  PublicSubnets:
+    Description: The internet-facing subnets.
+    Type: List<AWS::EC2::Subnet::Id>
+  PrivateSubnets:
+    Description: The internal subnets.
+    Type: List<AWS::EC2::Subnet::Id>
+  VpcId:
+    Description: The VPC-scoped resources will belong to this VPC.
+    Type: AWS::EC2::VPC::Id
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+    - Label:
+        default: "Cluster Information"
+      Parameters:
+      - ClusterName
+      - InfrastructureName
+    - Label:
+        default: "Network Configuration"
+      Parameters:
+      - VpcId
+      - PublicSubnets
+      - PrivateSubnets
+    - Label:
+        default: "DNS"
+      Parameters:
+      - HostedZoneName
+      - HostedZoneId
+    ParameterLabels:
+      ClusterName:
+        default: "Cluster Name"
+      InfrastructureName:
+        default: "Infrastructure Name"
+      VpcId:
+        default: "VPC ID"
+      PublicSubnets:
+        default: "Public Subnets"
+      PrivateSubnets:
+        default: "Private Subnets"
+      HostedZoneName:
+        default: "Public Hosted Zone Name"
+      HostedZoneId:
+        default: "Public Hosted Zone ID"
+
+Resources:
+  ExtApiElb:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: !Join ["-", [!Ref InfrastructureName, "ext"]]
+      IpAddressType: ipv4
+      Subnets: !Ref PublicSubnets
+      Type: network
+
+  IntApiElb:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: !Join ["-", [!Ref InfrastructureName, "int"]]
+      Scheme: internal
+      IpAddressType: ipv4
+      Subnets: !Ref PrivateSubnets
+      Type: network
+
+  IntDns:
+    Type: "AWS::Route53::HostedZone"
+    Properties:
+      HostedZoneConfig:
+        Comment: "Managed by CloudFormation"
+      Name: !Join [".", [!Ref ClusterName, !Ref HostedZoneName]]
+      HostedZoneTags:
+      - Key: Name
+        Value: !Join ["-", [!Ref InfrastructureName, "int"]]
+      - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
+        Value: "owned"
+      VPCs:
+      - VPCId: !Ref VpcId
+        VPCRegion: !Ref "AWS::Region"
+
+  ExternalApiServerRecord:
+    Type: AWS::Route53::RecordSetGroup
+    Properties:
+      Comment: Alias record for the API server
+      HostedZoneId: !Ref HostedZoneId
+      RecordSets:
+      - Name:
+          !Join [
+            ".",
+            ["api", !Ref ClusterName, !Join ["", [!Ref HostedZoneName, "."]]],
+          ]
+        Type: A
+        AliasTarget:
+          HostedZoneId: !GetAtt ExtApiElb.CanonicalHostedZoneID
+          DNSName: !GetAtt ExtApiElb.DNSName
+
+  InternalApiServerRecord:
+    Type: AWS::Route53::RecordSetGroup
+    Properties:
+      Comment: Alias record for the API server
+      HostedZoneId: !Ref IntDns
+      RecordSets:
+      - Name:
+          !Join [
+            ".",
+            ["api", !Ref ClusterName, !Join ["", [!Ref HostedZoneName, "."]]],
+          ]
+        Type: A
+        AliasTarget:
+          HostedZoneId: !GetAtt IntApiElb.CanonicalHostedZoneID
+          DNSName: !GetAtt IntApiElb.DNSName
+      - Name:
+          !Join [
+            ".",
+            ["api-int", !Ref ClusterName, !Join ["", [!Ref HostedZoneName, "."]]],
+          ]
+        Type: A
+        AliasTarget:
+          HostedZoneId: !GetAtt IntApiElb.CanonicalHostedZoneID
+          DNSName: !GetAtt IntApiElb.DNSName
+
+  ExternalApiListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+      - Type: forward
+        TargetGroupArn:
+          Ref: ExternalApiTargetGroup
+      LoadBalancerArn:
+        Ref: ExtApiElb
+      Port: 6443
+      Protocol: TCP
+
+  ExternalApiTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 10
+      HealthCheckPath: "/readyz"
+      HealthCheckPort: 6443
+      HealthCheckProtocol: HTTPS
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 2
+      Port: 6443
+      Protocol: TCP
+      TargetType: ip
+      VpcId:
+        Ref: VpcId
+      TargetGroupAttributes:
+      - Key: deregistration_delay.timeout_seconds
+        Value: 60
+
+  InternalApiListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+      - Type: forward
+        TargetGroupArn:
+          Ref: InternalApiTargetGroup
+      LoadBalancerArn:
+        Ref: IntApiElb
+      Port: 6443
+      Protocol: TCP
+
+  InternalApiTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 10
+      HealthCheckPath: "/readyz"
+      HealthCheckPort: 6443
+      HealthCheckProtocol: HTTPS
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 2
+      Port: 6443
+      Protocol: TCP
+      TargetType: ip
+      VpcId:
+        Ref: VpcId
+      TargetGroupAttributes:
+      - Key: deregistration_delay.timeout_seconds
+        Value: 60
+
+  InternalServiceInternalListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+      - Type: forward
+        TargetGroupArn:
+          Ref: InternalServiceTargetGroup
+      LoadBalancerArn:
+        Ref: IntApiElb
+      Port: 22623
+      Protocol: TCP
+
+  InternalServiceTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 10
+      HealthCheckPath: "/healthz"
+      HealthCheckPort: 22623
+      HealthCheckProtocol: HTTPS
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 2
+      Port: 22623
+      Protocol: TCP
+      TargetType: ip
+      VpcId:
+        Ref: VpcId
+      TargetGroupAttributes:
+      - Key: deregistration_delay.timeout_seconds
+        Value: 60
+
+  RegisterTargetLambdaIamRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Join ["-", [!Ref InfrastructureName, "nlb", "lambda", "role"]]
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        - Effect: "Allow"
+          Principal:
+            Service:
+            - "lambda.amazonaws.com"
+          Action:
+          - "sts:AssumeRole"
+      Path: "/"
+      Policies:
+      - PolicyName: !Join ["-", [!Ref InfrastructureName, "master", "policy"]]
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: "Allow"
+            Action:
+              [
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets",
+              ]
+            Resource: !Ref InternalApiTargetGroup
+          - Effect: "Allow"
+            Action:
+              [
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets",
+              ]
+            Resource: !Ref InternalServiceTargetGroup
+          - Effect: "Allow"
+            Action:
+              [
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets",
+              ]
+            Resource: !Ref ExternalApiTargetGroup
+
+  RegisterNlbIpTargets:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Handler: "index.handler"
+      Role:
+        Fn::GetAtt:
+        - "RegisterTargetLambdaIamRole"
+        - "Arn"
+      Code:
+        ZipFile: |
+          import json
+          import boto3
+          import cfnresponse
+          def handler(event, context):
+            elb = boto3.client('elbv2')
+            if event['RequestType'] == 'Delete':
+              elb.deregister_targets(TargetGroupArn=event['ResourceProperties']['TargetArn'],Targets=[{'Id': event['ResourceProperties']['TargetIp']}])
+            elif event['RequestType'] == 'Create':
+              elb.register_targets(TargetGroupArn=event['ResourceProperties']['TargetArn'],Targets=[{'Id': event['ResourceProperties']['TargetIp']}])
+            responseData = {}
+            cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, event['ResourceProperties']['TargetArn']+event['ResourceProperties']['TargetIp'])
+      Runtime: "python3.7"
+      Timeout: 120
+
+  RegisterSubnetTagsLambdaIamRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Join ["-", [!Ref InfrastructureName, "subnet-tags-lambda-role"]]
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        - Effect: "Allow"
+          Principal:
+            Service:
+            - "lambda.amazonaws.com"
+          Action:
+          - "sts:AssumeRole"
+      Path: "/"
+      Policies:
+      - PolicyName: !Join ["-", [!Ref InfrastructureName, "subnet-tagging-policy"]]
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: "Allow"
+            Action:
+              [
+                "ec2:DeleteTags",
+                "ec2:CreateTags"
+              ]
+            Resource: "arn:aws:ec2:*:*:subnet/*"
+          - Effect: "Allow"
+            Action:
+              [
+                "ec2:DescribeSubnets",
+                "ec2:DescribeTags"
+              ]
+            Resource: "*"
+
+  RegisterSubnetTags:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Handler: "index.handler"
+      Role:
+        Fn::GetAtt:
+        - "RegisterSubnetTagsLambdaIamRole"
+        - "Arn"
+      Code:
+        ZipFile: |
+          import json
+          import boto3
+          import cfnresponse
+          def handler(event, context):
+            ec2_client = boto3.client('ec2')
+            if event['RequestType'] == 'Delete':
+              for subnet_id in event['ResourceProperties']['Subnets']:
+                ec2_client.delete_tags(Resources=[subnet_id], Tags=[{'Key': 'kubernetes.io/cluster/' + event['ResourceProperties']['InfrastructureName']}]);
+            elif event['RequestType'] == 'Create':
+              for subnet_id in event['ResourceProperties']['Subnets']:
+                ec2_client.create_tags(Resources=[subnet_id], Tags=[{'Key': 'kubernetes.io/cluster/' + event['ResourceProperties']['InfrastructureName'], 'Value': 'shared'}]);
+            responseData = {}
+            cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, event['ResourceProperties']['InfrastructureName']+event['ResourceProperties']['Subnets'][0])
+      Runtime: "python3.7"
+      Timeout: 120
+
+  RegisterPublicSubnetTags:
+    Type: Custom::SubnetRegister
+    Properties:
+      ServiceToken: !GetAtt RegisterSubnetTags.Arn
+      InfrastructureName: !Ref InfrastructureName
+      Subnets: !Ref PublicSubnets
+
+  RegisterPrivateSubnetTags:
+    Type: Custom::SubnetRegister
+    Properties:
+      ServiceToken: !GetAtt RegisterSubnetTags.Arn
+      InfrastructureName: !Ref InfrastructureName
+      Subnets: !Ref PrivateSubnets
+
+Outputs:
+  PrivateHostedZoneId:
+    Description: Hosted zone ID for the private DNS, which is required for private records.
+    Value: !Ref IntDns
+  ExternalApiLoadBalancerName:
+    Description: Full name of the external API load balancer.
+    Value: !GetAtt ExtApiElb.LoadBalancerFullName
+  InternalApiLoadBalancerName:
+    Description: Full name of the internal API load balancer.
+    Value: !GetAtt IntApiElb.LoadBalancerFullName
+  ApiServerDnsName:
+    Description: Full hostname of the API server, which is required for the Ignition config files.
+    Value: !Join [".", ["api-int", !Ref ClusterName, !Ref HostedZoneName]]
+  RegisterNlbIpTargetsLambda:
+    Description: Lambda ARN useful to help register or deregister IP targets for these load balancers.
+    Value: !GetAtt RegisterNlbIpTargets.Arn
+  ExternalApiTargetGroupArn:
+    Description: ARN of the external API target group.
+    Value: !Ref ExternalApiTargetGroup
+  InternalApiTargetGroupArn:
+    Description: ARN of the internal API target group.
+    Value: !Ref InternalApiTargetGroup
+  InternalServiceTargetGroupArn:
+    Description: ARN of the internal service target group.
+    Value: !Ref InternalServiceTargetGroup

--- a/courses/ocp4_advanced_deployment/lab_03_1aws/files/aws_upi_sec_template.yaml
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/files/aws_upi_sec_template.yaml
@@ -1,0 +1,486 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Template for OpenShift Cluster Security Elements (Security Groups & IAM)
+
+Parameters:
+  InfrastructureName:
+    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
+    MaxLength: 27
+    MinLength: 1
+    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
+    Description: A short, unique cluster ID used to tag cloud resources and identify items owned or used by the cluster.
+    Type: String
+  VpcCidr:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-4]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-24.
+    Default: 10.0.0.0/16
+    Description: CIDR block for VPC.
+    Type: String
+  VpcId:
+    Description: The VPC-scoped resources will belong to this VPC.
+    Type: AWS::EC2::VPC::Id
+  PrivateSubnets:
+    Description: The internal subnets.
+    Type: List<AWS::EC2::Subnet::Id>
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+    - Label:
+        default: "Cluster Information"
+      Parameters:
+      - InfrastructureName
+    - Label:
+        default: "Network Configuration"
+      Parameters:
+      - VpcId
+      - VpcCidr
+      - PrivateSubnets
+    ParameterLabels:
+      InfrastructureName:
+        default: "Infrastructure Name"
+      VpcId:
+        default: "VPC ID"
+      VpcCidr:
+        default: "VPC CIDR"
+      PrivateSubnets:
+        default: "Private Subnets"
+
+Resources:
+  MasterSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Cluster Master Security Group
+      SecurityGroupIngress:
+      - IpProtocol: icmp
+        FromPort: 0
+        ToPort: 0
+        CidrIp: !Ref VpcCidr
+      - IpProtocol: tcp
+        FromPort: 22
+        ToPort: 22
+        CidrIp: !Ref VpcCidr
+      - IpProtocol: tcp
+        ToPort: 6443
+        FromPort: 6443
+        CidrIp: !Ref VpcCidr
+      - IpProtocol: tcp
+        FromPort: 22623
+        ToPort: 22623
+        CidrIp: !Ref VpcCidr
+      VpcId: !Ref VpcId
+
+  WorkerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Cluster Worker Security Group
+      SecurityGroupIngress:
+      - IpProtocol: icmp
+        FromPort: 0
+        ToPort: 0
+        CidrIp: !Ref VpcCidr
+      - IpProtocol: tcp
+        FromPort: 22
+        ToPort: 22
+        CidrIp: !Ref VpcCidr
+      VpcId: !Ref VpcId
+
+  MasterIngressEtcd:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: etcd
+      FromPort: 2379
+      ToPort: 2380
+      IpProtocol: tcp
+
+  MasterIngressVxlan:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: Vxlan packets
+      FromPort: 4789
+      ToPort: 4789
+      IpProtocol: udp
+
+  MasterIngressWorkerVxlan:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: Vxlan packets
+      FromPort: 4789
+      ToPort: 4789
+      IpProtocol: udp
+
+  MasterIngressGeneve:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: Geneve packets
+      FromPort: 6081
+      ToPort: 6081
+      IpProtocol: udp
+
+  MasterIngressWorkerGeneve:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: Geneve packets
+      FromPort: 6081
+      ToPort: 6081
+      IpProtocol: udp
+
+  MasterIngressInternal:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: Internal cluster communication
+      FromPort: 9000
+      ToPort: 9999
+      IpProtocol: tcp
+
+  MasterIngressWorkerInternal:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: Internal cluster communication
+      FromPort: 9000
+      ToPort: 9999
+      IpProtocol: tcp
+
+  MasterIngressInternalUDP:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: Internal cluster communication
+      FromPort: 9000
+      ToPort: 9999
+      IpProtocol: udp
+
+  MasterIngressWorkerInternalUDP:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: Internal cluster communication
+      FromPort: 9000
+      ToPort: 9999
+      IpProtocol: udp
+
+  MasterIngressKube:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: Kubernetes kubelet, scheduler and controller manager
+      FromPort: 10250
+      ToPort: 10259
+      IpProtocol: tcp
+
+  MasterIngressWorkerKube:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: Kubernetes kubelet, scheduler and controller manager
+      FromPort: 10250
+      ToPort: 10259
+      IpProtocol: tcp
+
+  MasterIngressIngressServices:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: Kubernetes ingress services
+      FromPort: 30000
+      ToPort: 32767
+      IpProtocol: tcp
+
+  MasterIngressWorkerIngressServices:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: Kubernetes ingress services
+      FromPort: 30000
+      ToPort: 32767
+      IpProtocol: tcp
+
+  MasterIngressIngressServicesUDP:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: Kubernetes ingress services
+      FromPort: 30000
+      ToPort: 32767
+      IpProtocol: udp
+
+  MasterIngressWorkerIngressServicesUDP:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: Kubernetes ingress services
+      FromPort: 30000
+      ToPort: 32767
+      IpProtocol: udp
+
+  WorkerIngressVxlan:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt WorkerSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: Vxlan packets
+      FromPort: 4789
+      ToPort: 4789
+      IpProtocol: udp
+
+  WorkerIngressMasterVxlan:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt WorkerSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: Vxlan packets
+      FromPort: 4789
+      ToPort: 4789
+      IpProtocol: udp
+
+  WorkerIngressGeneve:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt WorkerSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: Geneve packets
+      FromPort: 6081
+      ToPort: 6081
+      IpProtocol: udp
+
+  WorkerIngressMasterGeneve:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt WorkerSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: Geneve packets
+      FromPort: 6081
+      ToPort: 6081
+      IpProtocol: udp
+
+  WorkerIngressInternal:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt WorkerSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: Internal cluster communication
+      FromPort: 9000
+      ToPort: 9999
+      IpProtocol: tcp
+
+  WorkerIngressMasterInternal:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt WorkerSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: Internal cluster communication
+      FromPort: 9000
+      ToPort: 9999
+      IpProtocol: tcp
+
+  WorkerIngressInternalUDP:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt WorkerSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: Internal cluster communication
+      FromPort: 9000
+      ToPort: 9999
+      IpProtocol: udp
+
+  WorkerIngressMasterInternalUDP:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt WorkerSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: Internal cluster communication
+      FromPort: 9000
+      ToPort: 9999
+      IpProtocol: udp
+
+  WorkerIngressKube:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt WorkerSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: Kubernetes secure kubelet port
+      FromPort: 10250
+      ToPort: 10250
+      IpProtocol: tcp
+
+  WorkerIngressWorkerKube:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt WorkerSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: Internal Kubernetes communication
+      FromPort: 10250
+      ToPort: 10250
+      IpProtocol: tcp
+
+  WorkerIngressIngressServices:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt WorkerSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: Kubernetes ingress services
+      FromPort: 30000
+      ToPort: 32767
+      IpProtocol: tcp
+
+  WorkerIngressMasterIngressServices:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt WorkerSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: Kubernetes ingress services
+      FromPort: 30000
+      ToPort: 32767
+      IpProtocol: tcp
+
+  WorkerIngressIngressServicesUDP:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt WorkerSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: Kubernetes ingress services
+      FromPort: 30000
+      ToPort: 32767
+      IpProtocol: udp
+
+  WorkerIngressMasterIngressServicesUDP:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt WorkerSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: Kubernetes ingress services
+      FromPort: 30000
+      ToPort: 32767
+      IpProtocol: udp
+
+  MasterIamRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        - Effect: "Allow"
+          Principal:
+            Service:
+            - "ec2.amazonaws.com"
+          Action:
+          - "sts:AssumeRole"
+      Policies:
+      - PolicyName: !Join ["-", [!Ref InfrastructureName, "master", "policy"]]
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: "Allow"
+            Action:
+            - "ec2:AttachVolume"
+            - "ec2:AuthorizeSecurityGroupIngress"
+            - "ec2:CreateSecurityGroup"
+            - "ec2:CreateTags"
+            - "ec2:CreateVolume"
+            - "ec2:DeleteSecurityGroup"
+            - "ec2:DeleteVolume"
+            - "ec2:Describe*"
+            - "ec2:DetachVolume"
+            - "ec2:ModifyInstanceAttribute"
+            - "ec2:ModifyVolume"
+            - "ec2:RevokeSecurityGroupIngress"
+            - "elasticloadbalancing:AddTags"
+            - "elasticloadbalancing:AttachLoadBalancerToSubnets"
+            - "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer"
+            - "elasticloadbalancing:CreateListener"
+            - "elasticloadbalancing:CreateLoadBalancer"
+            - "elasticloadbalancing:CreateLoadBalancerPolicy"
+            - "elasticloadbalancing:CreateLoadBalancerListeners"
+            - "elasticloadbalancing:CreateTargetGroup"
+            - "elasticloadbalancing:ConfigureHealthCheck"
+            - "elasticloadbalancing:DeleteListener"
+            - "elasticloadbalancing:DeleteLoadBalancer"
+            - "elasticloadbalancing:DeleteLoadBalancerListeners"
+            - "elasticloadbalancing:DeleteTargetGroup"
+            - "elasticloadbalancing:DeregisterInstancesFromLoadBalancer"
+            - "elasticloadbalancing:DeregisterTargets"
+            - "elasticloadbalancing:Describe*"
+            - "elasticloadbalancing:DetachLoadBalancerFromSubnets"
+            - "elasticloadbalancing:ModifyListener"
+            - "elasticloadbalancing:ModifyLoadBalancerAttributes"
+            - "elasticloadbalancing:ModifyTargetGroup"
+            - "elasticloadbalancing:ModifyTargetGroupAttributes"
+            - "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
+            - "elasticloadbalancing:RegisterTargets"
+            - "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
+            - "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
+            - "kms:DescribeKey"
+            Resource: "*"
+
+  MasterInstanceProfile:
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      Roles:
+      - Ref: "MasterIamRole"
+
+  WorkerIamRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        - Effect: "Allow"
+          Principal:
+            Service:
+            - "ec2.amazonaws.com"
+          Action:
+          - "sts:AssumeRole"
+      Policies:
+      - PolicyName: !Join ["-", [!Ref InfrastructureName, "worker", "policy"]]
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: "Allow"
+            Action:
+            - "ec2:DescribeInstances"
+            - "ec2:DescribeRegions"
+            Resource: "*"
+
+  WorkerInstanceProfile:
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      Roles:
+      - Ref: "WorkerIamRole"
+
+Outputs:
+  MasterSecurityGroupId:
+    Description: Master Security Group ID
+    Value: !GetAtt MasterSecurityGroup.GroupId
+
+  WorkerSecurityGroupId:
+    Description: Worker Security Group ID
+    Value: !GetAtt WorkerSecurityGroup.GroupId
+
+  MasterInstanceProfile:
+    Description: Master IAM Instance Profile
+    Value: !Ref MasterInstanceProfile
+
+  WorkerInstanceProfile:
+    Description: Worker IAM Instance Profile
+    Value: !Ref WorkerInstanceProfile

--- a/courses/ocp4_advanced_deployment/lab_03_1aws/files/aws_upi_vpc_parameters.json
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/files/aws_upi_vpc_parameters.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ParameterKey": "VpcCidr",
+    "ParameterValue": "10.0.0.0/16"
+  },
+  {
+    "ParameterKey": "AvailabilityZoneCount",
+    "ParameterValue": "1"
+  },
+  {
+    "ParameterKey": "SubnetBits",
+    "ParameterValue": "12"
+  }
+]

--- a/courses/ocp4_advanced_deployment/lab_03_1aws/files/aws_upi_vpc_template.yaml
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/files/aws_upi_vpc_template.yaml
@@ -1,0 +1,288 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Template for Best Practice VPC with 1-3 AZs
+
+Parameters:
+  VpcCidr:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-4]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-24.
+    Default: 10.0.0.0/16
+    Description: CIDR block for VPC.
+    Type: String
+  AvailabilityZoneCount:
+    ConstraintDescription: "The number of availability zones. (Min: 1, Max: 3)"
+    MinValue: 1
+    MaxValue: 3
+    Default: 1
+    Description: "How many AZs to create VPC subnets for. (Min: 1, Max: 3)"
+    Type: Number
+  SubnetBits:
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/19-27.
+    MinValue: 5
+    MaxValue: 13
+    Default: 12
+    Description: "Size of each subnet to create within the availability zones. (Min: 5 = /27, Max: 13 = /19)"
+    Type: Number
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+    - Label:
+        default: "Network Configuration"
+      Parameters:
+      - VpcCidr
+      - SubnetBits
+    - Label:
+        default: "Availability Zones"
+      Parameters:
+      - AvailabilityZoneCount
+    ParameterLabels:
+      AvailabilityZoneCount:
+        default: "Availability Zone Count"
+      VpcCidr:
+        default: "VPC CIDR"
+      SubnetBits:
+        default: "Bits Per Subnet"
+
+Conditions:
+  DoAz3: !Equals [3, !Ref AvailabilityZoneCount]
+  DoAz2: !Or [!Equals [2, !Ref AvailabilityZoneCount], Condition: DoAz3]
+
+Resources:
+  VPC:
+    Type: "AWS::EC2::VPC"
+    Properties:
+      EnableDnsSupport: "true"
+      EnableDnsHostnames: "true"
+      CidrBlock: !Ref VpcCidr
+  PublicSubnet:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [0, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
+      AvailabilityZone: !Select
+      - 0
+      - Fn::GetAZs: !Ref "AWS::Region"
+  PublicSubnet2:
+    Type: "AWS::EC2::Subnet"
+    Condition: DoAz2
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [1, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
+      AvailabilityZone: !Select
+      - 1
+      - Fn::GetAZs: !Ref "AWS::Region"
+  PublicSubnet3:
+    Type: "AWS::EC2::Subnet"
+    Condition: DoAz3
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [2, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
+      AvailabilityZone: !Select
+      - 2
+      - Fn::GetAZs: !Ref "AWS::Region"
+  InternetGateway:
+    Type: "AWS::EC2::InternetGateway"
+  GatewayToInternet:
+    Type: "AWS::EC2::VPCGatewayAttachment"
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+  PublicRouteTable:
+    Type: "AWS::EC2::RouteTable"
+    Properties:
+      VpcId: !Ref VPC
+  PublicRoute:
+    Type: "AWS::EC2::Route"
+    DependsOn: GatewayToInternet
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+  PublicSubnetRouteTableAssociation:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId: !Ref PublicSubnet
+      RouteTableId: !Ref PublicRouteTable
+  PublicSubnetRouteTableAssociation2:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Condition: DoAz2
+    Properties:
+      SubnetId: !Ref PublicSubnet2
+      RouteTableId: !Ref PublicRouteTable
+  PublicSubnetRouteTableAssociation3:
+    Condition: DoAz3
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId: !Ref PublicSubnet3
+      RouteTableId: !Ref PublicRouteTable
+  PrivateSubnet:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [3, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
+      AvailabilityZone: !Select
+      - 0
+      - Fn::GetAZs: !Ref "AWS::Region"
+  PrivateRouteTable:
+    Type: "AWS::EC2::RouteTable"
+    Properties:
+      VpcId: !Ref VPC
+  PrivateSubnetRouteTableAssociation:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId: !Ref PrivateSubnet
+      RouteTableId: !Ref PrivateRouteTable
+  NAT:
+    DependsOn:
+    - GatewayToInternet
+    Type: "AWS::EC2::NatGateway"
+    Properties:
+      AllocationId:
+        "Fn::GetAtt":
+        - EIP
+        - AllocationId
+      SubnetId: !Ref PublicSubnet
+  EIP:
+    Type: "AWS::EC2::EIP"
+    Properties:
+      Domain: vpc
+  Route:
+    Type: "AWS::EC2::Route"
+    Properties:
+      RouteTableId:
+        Ref: PrivateRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId:
+        Ref: NAT
+  PrivateSubnet2:
+    Type: "AWS::EC2::Subnet"
+    Condition: DoAz2
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [4, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
+      AvailabilityZone: !Select
+      - 1
+      - Fn::GetAZs: !Ref "AWS::Region"
+  PrivateRouteTable2:
+    Type: "AWS::EC2::RouteTable"
+    Condition: DoAz2
+    Properties:
+      VpcId: !Ref VPC
+  PrivateSubnetRouteTableAssociation2:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Condition: DoAz2
+    Properties:
+      SubnetId: !Ref PrivateSubnet2
+      RouteTableId: !Ref PrivateRouteTable2
+  NAT2:
+    DependsOn:
+    - GatewayToInternet
+    Type: "AWS::EC2::NatGateway"
+    Condition: DoAz2
+    Properties:
+      AllocationId:
+        "Fn::GetAtt":
+        - EIP2
+        - AllocationId
+      SubnetId: !Ref PublicSubnet2
+  EIP2:
+    Type: "AWS::EC2::EIP"
+    Condition: DoAz2
+    Properties:
+      Domain: vpc
+  Route2:
+    Type: "AWS::EC2::Route"
+    Condition: DoAz2
+    Properties:
+      RouteTableId:
+        Ref: PrivateRouteTable2
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId:
+        Ref: NAT2
+  PrivateSubnet3:
+    Type: "AWS::EC2::Subnet"
+    Condition: DoAz3
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [5, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
+      AvailabilityZone: !Select
+      - 2
+      - Fn::GetAZs: !Ref "AWS::Region"
+  PrivateRouteTable3:
+    Type: "AWS::EC2::RouteTable"
+    Condition: DoAz3
+    Properties:
+      VpcId: !Ref VPC
+  PrivateSubnetRouteTableAssociation3:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Condition: DoAz3
+    Properties:
+      SubnetId: !Ref PrivateSubnet3
+      RouteTableId: !Ref PrivateRouteTable3
+  NAT3:
+    DependsOn:
+    - GatewayToInternet
+    Type: "AWS::EC2::NatGateway"
+    Condition: DoAz3
+    Properties:
+      AllocationId:
+        "Fn::GetAtt":
+        - EIP3
+        - AllocationId
+      SubnetId: !Ref PublicSubnet3
+  EIP3:
+    Type: "AWS::EC2::EIP"
+    Condition: DoAz3
+    Properties:
+      Domain: vpc
+  Route3:
+    Type: "AWS::EC2::Route"
+    Condition: DoAz3
+    Properties:
+      RouteTableId:
+        Ref: PrivateRouteTable3
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId:
+        Ref: NAT3
+  S3Endpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Effect: Allow
+          Principal: '*'
+          Action:
+          - '*'
+          Resource:
+          - '*'
+      RouteTableIds:
+      - !Ref PublicRouteTable
+      - !Ref PrivateRouteTable
+      - !If [DoAz2, !Ref PrivateRouteTable2, !Ref "AWS::NoValue"]
+      - !If [DoAz3, !Ref PrivateRouteTable3, !Ref "AWS::NoValue"]
+      ServiceName: !Join
+      - ''
+      - - com.amazonaws.
+        - !Ref 'AWS::Region'
+        - .s3
+      VpcId: !Ref VPC
+
+Outputs:
+  VpcId:
+    Description: ID of the new VPC.
+    Value: !Ref VPC
+  PublicSubnetIds:
+    Description: Subnet IDs of the public subnets.
+    Value:
+      !Join [
+        ",",
+        [!Ref PublicSubnet, !If [DoAz2, !Ref PublicSubnet2, !Ref "AWS::NoValue"], !If [DoAz3, !Ref PublicSubnet3, !Ref "AWS::NoValue"]]
+      ]
+  PrivateSubnetIds:
+    Description: Subnet IDs of the private subnets.
+    Value:
+      !Join [
+        ",",
+        [!Ref PrivateSubnet, !If [DoAz2, !Ref PrivateSubnet2, !Ref "AWS::NoValue"], !If [DoAz3, !Ref PrivateSubnet3, !Ref "AWS::NoValue"]]
+      ]

--- a/courses/ocp4_advanced_deployment/lab_03_1aws/files/aws_upi_worker_template.yaml
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/files/aws_upi_worker_template.yaml
@@ -1,0 +1,132 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Template for OpenShift Cluster Node Launch (EC2 worker instance)
+
+Parameters:
+  InfrastructureName:
+    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
+    MaxLength: 27
+    MinLength: 1
+    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
+    Description: A short, unique cluster ID used to tag nodes for the kubelet cloud provider.
+    Type: String
+  RhcosAmi:
+    Description: Current Red Hat Enterprise Linux CoreOS AMI to use for bootstrap.
+    Type: AWS::EC2::Image::Id
+  Subnet:
+    Description: The subnets, recommend private, to launch the master nodes into.
+    Type: AWS::EC2::Subnet::Id
+  WorkerSecurityGroupId:
+    Description: The master security group ID to associate with master nodes.
+    Type: AWS::EC2::SecurityGroup::Id
+  IgnitionLocation:
+    Default: https://api-int.$CLUSTER_NAME.$DOMAIN:22623/config/worker
+    Description: Ignition config file location.
+    Type: String
+  CertificateAuthorities:
+    Default: data:text/plain;charset=utf-8;base64,ABC...xYz==
+    Description: Base64 encoded certificate authority string to use.
+    Type: String
+  WorkerInstanceProfileName:
+    Description: IAM profile to associate with master nodes.
+    Type: String
+  WorkerInstanceType:
+    Default: m5.large
+    Type: String
+    AllowedValues:
+    - "m4.large"
+    - "m4.xlarge"
+    - "m4.2xlarge"
+    - "m4.4xlarge"
+    - "m4.8xlarge"
+    - "m4.10xlarge"
+    - "m4.16xlarge"
+    - "m5.large"
+    - "m5.xlarge"
+    - "m5.2xlarge"
+    - "m5.4xlarge"
+    - "m5.8xlarge"
+    - "m5.10xlarge"
+    - "m5.16xlarge"
+    - "c4.large"
+    - "c4.xlarge"
+    - "c4.2xlarge"
+    - "c4.4xlarge"
+    - "c4.8xlarge"
+    - "r4.large"
+    - "r4.xlarge"
+    - "r4.2xlarge"
+    - "r4.4xlarge"
+    - "r4.8xlarge"
+    - "r4.16xlarge"
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+    - Label:
+        default: "Cluster Information"
+      Parameters:
+      - InfrastructureName
+    - Label:
+        default: "Host Information"
+      Parameters:
+      - WorkerInstanceType
+      - RhcosAmi
+      - IgnitionLocation
+      - CertificateAuthorities
+      - WorkerSecurityGroupId
+      - WorkerInstanceProfileName
+    - Label:
+        default: "Network Configuration"
+      Parameters:
+      - Subnet
+    ParameterLabels:
+      Subnet:
+        default: "Subnet"
+      InfrastructureName:
+        default: "Infrastructure Name"
+      WorkerInstanceType:
+        default: "Worker Instance Type"
+      WorkerInstanceProfileName:
+        default: "Worker Instance Profile Name"
+      RhcosAmi:
+        default: "Red Hat Enterprise Linux CoreOS AMI ID"
+      IgnitionLocation:
+        default: "Worker Ignition Source"
+      CertificateAuthorities:
+        default: "Ignition CA String"
+      WorkerSecurityGroupId:
+        default: "Worker Security Group ID"
+
+Resources:
+  Worker0:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref RhcosAmi
+      BlockDeviceMappings:
+      - DeviceName: /dev/xvda
+        Ebs:
+          VolumeSize: "120"
+          VolumeType: "gp2"
+      IamInstanceProfile: !Ref WorkerInstanceProfileName
+      InstanceType: !Ref WorkerInstanceType
+      NetworkInterfaces:
+      - AssociatePublicIpAddress: "false"
+        DeviceIndex: "0"
+        GroupSet:
+        - !Ref "WorkerSecurityGroupId"
+        SubnetId: !Ref "Subnet"
+      UserData:
+        Fn::Base64: !Sub
+        - '{"ignition":{"config":{"merge":[{"source":"${SOURCE}"}]},"security":{"tls":{"certificateAuthorities":[{"source":"${CA_BUNDLE}"}]}},"version":"3.1.0"}}'
+        - {
+          SOURCE: !Ref IgnitionLocation,
+          CA_BUNDLE: !Ref CertificateAuthorities,
+        }
+      Tags:
+      - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
+        Value: "shared"
+
+Outputs:
+  PrivateIP:
+    Description: The compute node private IP address.
+    Value: !GetAtt Worker0.PrivateIp

--- a/courses/ocp4_advanced_deployment/lab_03_1aws/files/bootstrap-ignition.json
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/files/bootstrap-ignition.json
@@ -1,0 +1,11 @@
+{
+  "ignition": {
+    "config": {
+      "merge": [{
+        "source": "http://utilityvm.example.com/bootstrap.ign"
+      }]
+    },
+    "security": {},
+    "version": "3.1.0"
+  }
+}

--- a/courses/ocp4_advanced_deployment/lab_03_1aws/files/ca-csr.json
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/files/ca-csr.json
@@ -1,0 +1,18 @@
+{
+    "CN": "Red Hat GPTE",
+    "hosts": [
+        "utilityvm.{{ guid }}.com"
+    ],
+    "key": {
+        "algo": "rsa",
+        "size": 2048
+    },
+    "names": [
+        {
+            "C": "US",
+            "ST": "Washington",
+            "L": "Seattle",
+            "OU": "GPTE"
+        }
+    ]
+}

--- a/courses/ocp4_advanced_deployment/lab_03_1aws/files/process.yaml
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/files/process.yaml
@@ -1,0 +1,10 @@
+- hosts: localhost
+  vars_files:
+    - cluster_vars.yaml
+
+  tasks:
+    - name: Process all the templates with cluster_vars.yaml
+      template:
+        src: "{{ item }}"
+        dest: "{{ item | splitext | first }}"
+      loop: "{{ lookup('fileglob', 'aws_upi*.j2', wantlist=True) }}"

--- a/courses/ocp4_advanced_deployment/lab_03_1aws/files/server.json
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/files/server.json
@@ -1,0 +1,18 @@
+{
+    "CN": "Red Hat GPTE",
+    "hosts": [
+        "utilityvm.{{ guid }}.com"
+    ],
+    "key": {
+        "algo": "ecdsa",
+        "size": 256
+    },
+    "names": [
+        {
+            "C": "US",
+            "ST": "Washington",
+            "L": "Seattle",
+            "OU": "GPTE"
+        }
+    ]
+}

--- a/courses/ocp4_advanced_deployment/lab_03_1aws/grade_lab.yml
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/grade_lab.yml
@@ -1,0 +1,55 @@
+---
+- name: Grade lab 03_1 of ocp4_advanced_deployment
+  hosts: localhost
+  gather_facts: false
+  become: false
+  vars:
+    ocp_version: 4.5.5
+  environment:
+    KUBECONFIG: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
+    OCP_RELEASE: "{{ ocp_version }}"
+  tasks:
+    - name: Check the clusterversion
+      include_role:
+        name: grader_check_ocp_resource
+      vars:
+        task_description_message: Check that the cluster version is correct.
+        resource_api_version: config.openshift.io/v1
+        resource_kind: ClusterVersion
+        resource_name: version
+        kubeconfig: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
+        student_error_message: "Cluster Version is not correct"
+        validate_certs: False
+        resource_definition_checks:
+        - error_message: Cluster not in an available state
+          json_query: "status.conditions[?type=='Available'].status|[0]"
+          value: "True"
+        - error_message: Cluster not at the correct version
+          json_query: "status.conditions[?type=='Available'].message|[0]"
+          value: "Done applying {{ ocp_version }}"
+
+    - name: Verify registry is accessible
+      include_role:
+        name: grader_check_uri_response
+      vars:
+        task_description_message: Check that the mirror registry is accessible.
+        url: "https://utilityvm.example.com:5000/v2/_catalog"
+        url_username: "openshift"
+        url_password: "redhat"
+
+    - name: Verify the OpenShift registry is available
+      include_role:
+        name: grader_check_ocp_resource
+      vars:
+        task_description_message: Check that the OpenShift registry is available.
+        resource_api_version: apps/v1
+        resource_kind: Deployment
+        resource_name: image-registry
+        resource_namespace: openshift-image-registry
+        kubeconfig: "{{ lookup('env', 'HOME') }}/openstack-upi/auth/kubeconfig"
+        student_error_message: "OpenShift registry is not available"
+        validate_certs: False
+        resource_definition_checks:
+        - error_message: OpenShift Image Registry is not available or does not have 2 replicas
+          json_query: "status.availableReplicas"
+          value: 2

--- a/courses/ocp4_advanced_deployment/lab_03_1aws/reset_lab.yml
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/reset_lab.yml
@@ -1,0 +1,141 @@
+---
+- name: Reset the OCP4 on OpenStack installation lab
+  hosts: localhost
+  gather_facts: false
+  become: false
+  vars:
+    guid: "{{ lookup('env', 'GUID') }}"
+
+  tasks:
+
+    - name: delete security groups dependent on installer SGs
+      debug:
+        msg: mark
+
+    - name: Get infra_id - if fails assume infra_id var from cli
+      shell: jq -r .infraID $HOME/aws-upi/metadata.json
+      register: r_infra_id
+
+    - name: set infra_id
+      when: r_infra_id.stdout is defined
+      set_fact:
+        infra_id: "{{ r_infra_id.stdout }}"
+
+    - name: get vpc_id
+      ec2_vpc_net_info:
+      register: r_vpcs
+
+    - name: openshift vpc
+      set_fact:
+        openshift_vpc_id: "{{ r_vpcs | to_json | from_json | json_query(openshift_vpc_query) | first }}"
+      vars:
+        openshift_vpc_query: |
+          vpcs[?cidr_block==`10.0.0.0/16`].vpc_id
+
+    - name: get routes for original vpc
+      ec2_vpc_route_table_info:
+        region: us-east-2
+      register: r_route_tables
+
+    - name: delete routes from original VPC
+      ignore_errors: true
+      shell: |
+        /usr/bin/aws ec2 delete-route --destination-cidr-block 10.0.0.0/16 --route-table-id {{ item }}
+      loop: "{{ r_route_tables.route_tables | map(attribute='id')  | list }}"
+
+    - name: get peering ID
+      ec2_vpc_peering_info:
+        region: us-east-2
+      register: r_peering_info
+
+    - name: delete peering connection
+      when: r_peering_info.result[0].vpc_peering_connection_id is defined
+      ec2_vpc_peer:
+        region: us-east-2
+        peering_id: "{{  r_peering_info.result[0].vpc_peering_connection_id }}"
+        state: absent
+
+    - name: get all hosted zones
+      route53_info:
+        query: hosted_zone
+      register: r_hosted_zones
+      tags:
+        - aws-query
+
+    - name: create a hosted zone name variable
+      set_fact:
+        sandbox_hosted_zone_name:
+          "{{ r_hosted_zones.HostedZones | to_json | from_json |
+            json_query('[? starts_with(Name, `sandbox`) ].Name' ) | first |
+            regex_replace('.$', '') }}"
+        sandbox_hosted_zone_id:
+          "{{ r_hosted_zones.HostedZones | to_json | from_json |
+              json_query('[? starts_with(Name, `sandbox`) ].Id' ) | first |
+              regex_replace('/hostedzone/', '') }}"
+        internal_hosted_zone_id:
+          "{{ r_hosted_zones.HostedZones | to_json | from_json |
+              json_query('[? contains(Name, `internal`) ].Id' ) | first |
+              regex_replace('/hostedzone/', '') }}"
+
+    - name: disassociate hosted zone for openshift VPC
+      ignore_errors: yes
+      shell: |
+        /usr/bin/aws route53 disassociate-vpc-from-hosted-zone --vpc VPCRegion=us-east-2,VPCId={{ openshift_vpc_id }} --hosted-zone-id {{ internal_hosted_zone_id }}
+
+    - name: cleanup resources files that were created in previous runs
+      file:
+        state: absent
+        path: "{{ item }}"
+      loop:
+        - "~/resources/*.txt"
+        - "~/resources/*.json"
+        - "~/resources/cluster_vars.yaml"
+
+    - name: delete s3 buckets
+      aws_s3_bucket_info:
+      register: r_buckets
+
+    - name: delete s3 buckets
+      aws_s3:
+        bucket: "{{ item.name }}"
+        mode: delete
+      loop: "{{ r_buckets['buckets'] }}"
+
+    - name: destroy cluster (to clean up AWS resources not in stacks)
+      async: 3600
+      poll: 0
+      ignore_errors: yes
+      shell:
+        /usr/local/sbin/openshift-install destroy cluster --dir $HOME/aws-upi/
+
+# if you cannot delete the $INFRA_ID-dns stack because of a dependency not owned by the AWS
+#  user, try this in ~/aws-up/metadata.json and run
+#  openshift-install destroy-cluster --dir $HOME/aws-upi/
+#{
+#    "clusterName": "cluster-be84",
+#    "clusterID": "639e5132-0c53-4ac3-873f-c92d6abc09be",
+#    "infraID": "INFRA_ID",
+#    "aws": {
+#        "region": "REGION",
+#        "identifier": [{
+#            "kubernetes.io/cluster/INFRA_ID": "owned"
+#        }]
+#    }
+#}
+    - name: Delete Stacks
+      ignore_errors: true
+      #async: 3600
+      #poll: 0
+      cloudformation:
+        state: absent
+        stack_name: "{{ infra_id }}-{{ item }}"
+      loop:
+        - bootstrap
+        - worker-2
+        - worker-1
+        - control-plane
+        - sec
+        - dns
+        - vpc
+
+

--- a/courses/ocp4_advanced_deployment/lab_03_1aws/solve_lab.yml
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/solve_lab.yml
@@ -1,0 +1,949 @@
+# vim:ft=yaml.ansible:
+---
+- name: Check Solver Prereqs
+  hosts: localhost
+  gather_facts: false
+  become: false
+  vars:
+    guid: "{{ lookup('env', 'GUID') }}"
+  tasks:
+    - name: Check for presence of GUID in environment
+      assert:
+       that:
+         guid is defined
+
+    - name: Check for presence of $HOME/.aws/credentials
+      stat:
+        path: $HOME/.aws/credentials
+      register: r_awscreds_stat
+
+    - name: assert presence of $HOME/.aws/credentials
+      assert:
+        that:
+          - r_awscreds_stat.stat.exists
+        fail_msg: "You must have your AWS credentials '$HOME/.aws/credentials' from OpenTLC to install OpenShift on AWS."
+
+    - name: Check for presence of $HOME/ocp_pullsecret.json
+      stat:
+        path: $HOME/ocp_pullsecret.json
+      register: r_pullsecret_stat
+
+    - name: assert presence of ocp_pullsecret.json
+      assert:
+        that:
+          - r_pullsecret_stat.stat.exists
+        fail_msg: "You must have your pull secret from Red Hat to install OpenShift."
+
+- name: run reset playbook if there's an infraid
+  hosts: localhost
+  gather_facts: no
+  run_once: true
+  tasks:
+
+   - name: get infraid
+     shell: |
+       jq -r .infraID $HOME/aws-upi/metadata.json
+     ignore_errors: true
+     register: r_infra_id
+
+   - name: what is going on
+     when: r_infra_id.stdout != ""
+     set_fact:
+       infra_id: "{{ r_infra_id.stdout }}"
+     delegate_to: localhost
+     delegate_facts: yes
+
+- name: Run reset_lab
+  import_playbook: reset_lab.yml
+  when: infra_id is defined
+
+
+- name: Solve the OCP4 on AWS installation lab - bastion prep
+  hosts: localhost
+  gather_facts: false
+  become: false
+  vars:
+    ocp_version: 4.6.18
+  environment:
+    OCP_RELEASE: "{{ ocp_version }}"
+
+  tasks:
+
+    - name: Remove old ~/aws-upi directory
+      file:
+        state: absent
+        path: "$HOME/aws-upi/"
+
+    - name: cleanup resources files that were created in previous runs
+      file:
+        state: absent
+        path: "{{ item }}"
+      loop:
+        - "~/resources/*.txt"
+        - "~/resources/*.json"
+        - "~/resources/cluster_vars.yaml"
+
+    - name: Set OCP version in bashrc
+      lineinfile:
+        path: $HOME/.bashrc
+        regexp: "^export OCP_RELEASE"
+        line: "export OCP_RELEASE={{ ocp_version }}"
+
+    - name: Install oc binary
+      unarchive:
+        src: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OCP_RELEASE/openshift-client-linux-$OCP_RELEASE.tar.gz
+        dest: /usr/local/sbin
+        remote_src: yes
+        mode: 0555
+      become: true
+
+    - name: Download aws binary
+      unarchive:
+        src: https://s3.amazonaws.com/aws-cli/awscli-bundle.zip
+        dest: $HOME/
+        remote_src: yes
+      become: true
+
+    - name: Install aws binary
+      become: yes
+      command: '/root/awscli-bundle/install -i /usr/local/aws -b /bin/aws'
+      args:
+        creates: /usr/local/aws
+
+    - name: Cleanup aws archive
+      file:
+        path: $HOME/awscli-bundle
+        state: absent
+      become: true
+
+    - name: Add utilityVM to inventory
+      add_host:
+        hostname: utilityvm
+
+- name: Solve the OCP4 on OpenStack installation lab - UtilityVM
+  vars:
+    guid: "{{ lookup('env', 'GUID') }}"
+  hosts: utilityvm
+  gather_facts: false
+  become: false
+
+  tasks:
+    - name: Pull UBI 8.3 image
+      podman_image:
+        name: registry.access.redhat.com/ubi8/ubi:8.3
+
+    - name: Test podman with UBI 8.3 image
+      command: "podman run --rm registry.access.redhat.com/ubi8/ubi:8.3 cat /etc/os-release"
+      register: podman_ubi
+
+    - debug:
+        var: podman_ubi
+
+    - name: Make directories for registry contents
+      file:
+        path: "/opt/registry/{{ item }}"
+        state: directory
+        owner: "ec2-user"
+        recurse: true
+      become: true
+      loop:
+        - auth
+        - certs
+        - data
+
+    - name: Getting required binaries
+      get_url:
+        url: "{{ item.url }}"
+        dest: "/usr/local/sbin/{{ item.name }}"
+        mode: 0555
+      become: true
+      loop:
+        - { url: 'https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssljson_1.5.0_linux_amd64', name: cfssljson }
+        - { url: 'https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl_1.5.0_linux_amd64', name: cfssl }
+
+    - name: certificate templates
+      template:
+        src: "./templates/{{ item }}.j2"
+        dest: "/opt/registry/certs/{{ item }}"
+      loop:
+       - ca-config.json
+       - ca-csr.json
+       - server.json
+      become: yes
+
+    - name: whoami
+      command: whoami
+
+    - name: Create self-signed certificate for registry
+      shell: "{{ item }}"
+      args:
+        chdir: /opt/registry/certs/
+      loop:
+        - "cfssl gencert -initca /opt/registry/certs/ca-csr.json | cfssljson -bare ca -"
+        - "cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=/opt/registry/certs/ca-config.json -profile=server /opt/registry/certs/server.json | cfssljson -bare server"
+
+    - name: Create htpasswd file
+      command: htpasswd -bBc /opt/registry/auth/htpasswd openshift redhat
+
+    - name: Stop container if it is running
+      shell: podman stop mirror-registry && podman rm mirror-registry
+      ignore_errors: true
+
+    - name: Stop container if it is running (root)
+      shell: podman stop mirror-registry && podman rm mirror-registry
+      become: true
+      ignore_errors: true
+
+    - name: Start container registry container
+      vars:
+        container_image: docker.io/library/registry:2
+        container_name: mirror-registry
+        container_run_args: >-
+          -p 5000:5000
+          --restart=always
+          -v /opt/registry/data:/var/lib/registry:z
+          -v /opt/registry/auth:/auth:z
+          -e "REGISTRY_AUTH=htpasswd"
+          -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm"
+          -e "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd"
+          -v /opt/registry/certs:/certs:z
+          -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/server.pem
+          -e REGISTRY_HTTP_TLS_KEY=/certs/server-key.pem
+        container_state: running
+      import_role:
+        name: ../../../roles/podman_container_systemd
+      become: true
+
+    - name: Stop mirror-registry service if running
+      service:
+        name: mirror-registry-container-pod
+        state: restarted
+      become: true
+      ignore_errors: true
+
+    - name: Move certificate to ca-trust
+      copy:
+        src: /opt/registry/certs/ca.pem
+        dest: /etc/pki/ca-trust/source/anchors/ca.pem
+        remote_src: true
+      become: true
+
+    - name: Update CA trust
+      command: update-ca-trust
+      become: true
+
+    - name: Test to ensure registry is accessible
+      uri:
+        url: https://utilityvm.{{ guid }}.internal:5000/v2/_catalog
+        status_code: 200
+        method: GET
+        url_username: openshift
+        url_password: redhat
+
+    - name: Test registry functionality
+      command: podman login -u openshift -p redhat utilityvm.{{ guid }}.internal:5000
+
+    - name: Test registry functionality
+      command: podman tag registry.access.redhat.com/ubi8/ubi:8.3 utilityvm.{{ guid }}.internal:5000/ubi8/ubi:8.3
+
+    - name: Test registry functionality
+      command: podman push utilityvm.{{ guid }}.internal:5000/ubi8/ubi:8.3
+
+- name: Solve the OCP4 on AWS installation lab - image mirror
+  hosts: localhost
+  gather_facts: false
+  become: false
+  vars:
+    HOME: "{{ lookup('env', 'HOME') }}"
+    ocp_version: 4.6.18
+    rhcos_image_version: "rhcos-ocp46"
+    guid: "{{ lookup('env', 'GUID') }}"
+  environment:
+    OCP_RELEASE: "{{ ocp_version }}"
+    LOCAL_REGISTRY: "utilityvm.{{ guid }}.internal:5000"
+    LOCAL_REPOSITORY: "ocp4/openshift4"
+    LOCAL_SECRET_JSON: "/home/{{ lookup('env', 'USER') }}/merged_pullsecret.json"
+    PRODUCT_REPO: "openshift-release-dev"
+    RELEASE_NAME: "ocp-release"
+
+  tasks:
+    #- set_fact:
+    #ansible_python_interpreter: /usr/bin/python3
+    #tags: test_prep
+
+    - name: get all hosted zones
+      route53_info:
+        query: hosted_zone
+      register: r_hosted_zones
+      tags:
+        - aws-query
+
+    - name: create a hosted zone name variable
+      set_fact:
+        sandbox_hosted_zone_name:
+          "{{ r_hosted_zones.HostedZones | to_json | from_json |
+            json_query('[? starts_with(Name, `sandbox`) ].Name' ) | first |
+            regex_replace('.$', '') }}"
+        sandbox_hosted_zone_id:
+          "{{ r_hosted_zones.HostedZones | to_json | from_json |
+              json_query('[? starts_with(Name, `sandbox`) ].Id' ) | first |
+              regex_replace('/hostedzone/', '') }}"
+        internal_hosted_zone_id:
+          "{{ r_hosted_zones.HostedZones | to_json | from_json |
+              json_query('[? contains(Name, `internal`) ].Id' ) | first |
+              regex_replace('/.$/', '') }}"
+      tags: aws-query
+
+    - name: Copy certificate from utility VM
+      command: scp utilityvm.{{ guid }}.internal:/opt/registry/certs/ca.pem /etc/pki/ca-trust/source/anchors/
+      become: true
+
+    - name: Update CA trust
+      command: update-ca-trust
+      become: true
+
+    - name: Verify registry is accessible
+      uri:
+        url: https://utilityvm.{{ guid }}.internal:5000/v2/_catalog
+        status_code: 200
+        method: GET
+        url_username: openshift
+        url_password: redhat
+
+    - name: Get podman credentials into file
+      command: podman login -u openshift -p redhat --authfile $HOME/pullsecret_config.json utilityvm.{{ guid }}.internal:5000
+
+    - name: Verify pull secret is valid syntax
+      assert:
+        that:
+          lookup('file', HOME ~ '/ocp_pullsecret.json') | from_json is succeeded
+        success_msg: The OCP pull secret has correct syntax
+      vars:
+        HOME: "{{ lookup('env', 'HOME') }}"
+
+    - name: Merge pull secrets
+      shell: >-
+        jq -c --argjson var "$(jq .auths $HOME/pullsecret_config.json)" '.auths += $var'
+        $HOME/ocp_pullsecret.json > $HOME/merged_pullsecret.json
+
+    - name: Add env vars to .bashrc
+      lineinfile:
+        path: $HOME/.bashrc
+        regexp: "^export {{ item.entry }}"
+        line: "export {{ item.entry }}={{ item.val }}"
+      loop:
+        - entry: "LOCAL_REGISTRY"
+          val: "utilityvm.{{ guid }}.internal:5000"
+        - entry: "LOCAL_REPOSITORY"
+          val: "ocp4/openshift4"
+        - entry: "LOCAL_SECRET_JSON"
+          val: "/home/{{ lookup('env', 'USER') }}/merged_pullsecret.json"
+        - entry: "PRODUCT_REPO"
+          val: "openshift-release-dev"
+        - entry: "RELEASE_NAME"
+          val: "ocp-release"
+        - entry: "OPENSHIFT_DNS_ZONE"
+          val: "{{ sandbox_hosted_zone_name }}"
+
+    - name: Mirror OpenShift content to local registry
+      shell: >-
+        /usr/local/sbin/oc adm -a ${LOCAL_SECRET_JSON} release mirror
+        --from=quay.io/${PRODUCT_REPO}/${RELEASE_NAME}:${OCP_RELEASE}-x86_64
+        --to=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}
+        --to-release-image=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-x86_64
+
+    - name: Verify that images are present and pullable
+      podman_image:
+        name: "utilityvm.{{ guid }}.internal:5000/ocp4/openshift4:${OCP_RELEASE}-operator-lifecycle-manager"
+        auth_file: "$HOME/merged_pullsecret.json"
+
+    - name: Check release info to make sure it works
+      shell: >-
+        /usr/local/sbin/oc adm release info -a ${LOCAL_SECRET_JSON}
+        "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-x86_64"
+      register: release_info
+
+    - name: Check release info to make sure it works
+      assert:
+        that:
+          - not release_info.failed
+          - "'{{ ocp_version }}' in release_info.stdout"
+
+    - name: Extract openshift-install binary
+      shell: >-
+        /usr/local/sbin/oc adm release extract -a ${LOCAL_SECRET_JSON}
+        --command=openshift-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-x86_64"
+        --to /usr/local/sbin/
+      become: true
+      environment:
+        OCP_RELEASE: "{{ ocp_version }}"
+        LOCAL_REGISTRY: "utilityvm.{{ guid }}.internal:5000"
+        LOCAL_REPOSITORY: "ocp4/openshift4"
+        LOCAL_SECRET_JSON: "/home/{{ lookup('env', 'USER') }}/merged_pullsecret.json"
+
+    - name: Create directory for installation artifacts
+      file:
+        state: directory
+        path: $HOME/aws-upi
+
+    - name: Create the install-config.yaml file
+      template:
+        src: ./templates/install-config.yaml.j2
+        dest: $HOME/aws-upi/install-config.yaml
+      vars:
+        GUID: "{{ lookup('env', 'GUID') }}"
+        HOME: "{{ lookup('env', 'HOME') }}"
+
+    - name: Backup the install-config just in case
+      file:
+        state: directory
+        path: $HOME/backup
+
+    - name: Backup the install-config just in case
+      copy:
+        src: $HOME/aws-upi/install-config.yaml
+        dest: $HOME/backup/install-config.yaml
+        remote_src: true
+
+    - name: Create openshift-install manifests
+      shell: /usr/local/sbin/openshift-install create manifests --dir $HOME/aws-upi
+
+    - name: Fix the cluster-scheduler manifest
+      lineinfile:
+        path: $HOME/aws-upi/manifests/cluster-scheduler-02-config.yml
+        regexp: "^  mastersSchedulable"
+        line: "  mastersSchedulable: false"
+
+    - name: Remove manifests for master machines
+      shell: rm -f $HOME/aws-upi/openshift/99_openshift-cluster-api_master-machines-*.yaml
+
+    - name: Create openshift-install ignition files
+      shell: /usr/local/sbin/openshift-install create ignition-configs --dir $HOME/aws-upi
+
+    - name: Set infra_id in .bashrc
+      lineinfile:
+        path: $HOME/.bashrc
+        regexp: "^export INFRA_ID"
+        line: "export INFRA_ID=$(jq -r .infraID $HOME/aws-upi/metadata.json)"
+
+    - name: Get infra_id
+      shell: jq -r .infraID $HOME/aws-upi/metadata.json
+      register: r_infra_id
+      tags:
+        - aws-query
+
+    - debug:
+        var: r_infra_id
+
+    - name: Add AWS env vars to .bashrc
+      lineinfile:
+        path: $HOME/.bashrc
+        regexp: "^export {{ item.entry }}"
+        line: "export {{ item.entry }}={{ item.val }}"
+      loop:
+        - entry: "CLUSTER_NAME"
+          val: "cluster-{{ guid }}"
+        - entry: "BASE_DOMAIN"
+          val: "{{ sandbox_hosted_zone_name }}"
+
+    - name: Add AWS env vars to $HOME/resources/cluster_vars.yaml
+      lineinfile:
+        path: $HOME/resources/cluster_vars.yaml
+        regexp: "^{{ item.entry }}"
+        line: "{{ item.entry }}: {{ item.val }}"
+        create: true
+      loop:
+        - entry: "INFRA_ID"
+          val: "{{ r_infra_id.stdout }}"
+        - entry: "CLUSTER_NAME"
+          val: "cluster-{{ guid }}"
+        - entry: "BASE_DOMAIN"
+          val: "{{ sandbox_hosted_zone_name }}"
+
+          ##########
+          ## Create VPC
+          ##########
+
+    - name: get original vpc_id
+      ec2_vpc_net_info:
+        filters:
+          "tag:guid": "{{ guid }}"
+      register: r_vpc_original
+      tags:
+        - aws-query
+
+    - name: original vpcid
+      set_fact:
+        original_vpc_id: "{{ r_vpc_original.vpcs[0].vpc_id }}"
+      tags:
+        - aws-query
+
+
+    - name: Create AWS VPC for OpenShift cluster
+      cloudformation:
+        stack_name: "{{ r_infra_id.stdout }}-vpc"
+        template: '~/resources/aws_upi_vpc_template.yaml'
+        template_parameters: "{{ lookup('file', HOME ~ '/resources/aws_upi_vpc_parameters.json') | from_json | items2dict(key_name='ParameterKey',value_name='ParameterValue') }}"
+      register: r_vpc_openshift
+      tags:
+        - aws-query
+
+    - name: openshift vpcid
+      set_fact:
+        openshift_vpc_id: "{{ r_vpc_openshift.stack_outputs.VpcId }}"
+      tags:
+        - aws-query
+
+    - name: Put VpcID, PublicSubnetId, PrivateSubnetIds into resources files
+      shell: >-
+        /usr/bin/aws cloudformation describe-stacks --stack-name $INFRA_ID-vpc
+        --query Stacks[0].Outputs[].[OutputKey,OutputValue] --output text |
+        sed 's_\s_: _g' |  tee ~/resources/vpc.txt >> ~/resources/cluster_vars.yaml
+      environment:
+        INFRA_ID: "{{ r_infra_id.stdout }}"
+      tags:
+        - aws-query
+
+          ##########
+          ## Create DNS
+          ##########
+
+    - name: Add the HostedZoneId to the ~/resources/cluster_vars.yaml
+      lineinfile:
+        path: "$HOME/resources/cluster_vars.yaml"
+        regexp: '^HostedZoneId'
+        line: "HostedZoneId: {{ sandbox_hosted_zone_id }}"
+      tags:
+        - aws-query
+
+    - name: Process the templates to generate ~/resources/aws_upi_route53_parameters.json
+      ignore_errors: true
+      shell: >-
+        ansible-playbook ./process.yaml
+      args:
+        chdir: ~/resources/
+      tags:
+        - aws-query
+
+    - name: Run the cloudformations template to update DNS and create ELBs
+      tags:
+        - aws-query
+      block:
+        - name: submit DNS/ELB cloudformations template
+          cloudformation:
+            stack_name: "{{ r_infra_id.stdout }}-dns"
+            template: '~/resources/aws_upi_route53_template.yaml'
+            template_parameters:
+              "{{ lookup('file', HOME ~ '/resources/aws_upi_route53_parameters.json') |
+              from_json | items2dict(key_name='ParameterKey',value_name='ParameterValue') }}"
+      rescue:
+        - name: delete DNS/ELB couldformation stack to retry
+          cloudformation:
+            stack_name: "{{ r_infra_id.stdout }}-dns"
+            state: absent
+
+        - name: submit DNS/ELB cloudformations template - again
+          cloudformation:
+            stack_name: "{{ r_infra_id.stdout }}-dns"
+            template: '~/resources/aws_upi_route53_template.yaml'
+            template_parameters:
+              "{{ lookup('file', HOME ~ '/resources/aws_upi_route53_parameters.json') |
+              from_json | items2dict(key_name='ParameterKey',value_name='ParameterValue') }}"
+
+    - name: Save many variables from DNS/ELB setup
+      shell: >-
+        aws cloudformation describe-stacks --stack-name ${INFRA_ID}-dns --query Stacks[0].Outputs[].[OutputKey,OutputValue] --output text | sed 's_\s_: _g' | tee ~/resources/dns.txt >> ~/resources/cluster_vars.yaml
+      environment:
+        INFRA_ID: "{{ r_infra_id.stdout }}"
+      tags:
+        - aws-query
+        #
+          ##########
+          ## Create VPC Perring and Routes
+          ##########
+
+    - name: set Hosted Zone IDand openshift vpc
+      ignore_errors: true
+      shell: |
+        aws route53 associate-vpc-with-hosted-zone \
+        --hosted-zone-id="{{ internal_hosted_zone_id }}" \
+        --vpc VPCRegion=us-east-2,VPCId={{ openshift_vpc_id }}
+      tags:
+        - aws-query
+
+      #      route53:
+      #        zone: "{{ guid }}.internal."
+      #        vpc_id: "{{ openshift_vpc_id }}"
+      #        vpc_region: us-east-2
+      #      tags:
+      #        - aws-query
+
+    - name: create peering connection
+      ec2_vpc_peer:
+        region: us-east-2
+        vpc_id: "{{ openshift_vpc_id }}"
+        peer_vpc_id: "{{ original_vpc_id }}"
+        state: present
+      register: vpc_peer
+      tags:
+        - aws-query
+
+    - name: accept local VPC peering request
+      ec2_vpc_peer:
+        region: us-east-2
+        peering_id: "{{ vpc_peer.peering_id }}"
+        state: accept
+      register: action_peer
+      tags:
+        - aws-query
+
+         ######
+         ######
+         ### Routes
+         #####
+         #####
+
+    - name: get routes for openshift vpc
+      ec2_vpc_route_table_info:
+        region: us-east-2
+        filters:
+          vpc-id: "{{ openshift_vpc_id }}"
+      register: openshift_route_tables
+      tags:
+        - aws-query
+
+    - name: debug route tables
+      debug:
+        var: openshift_route_tables
+
+    - name: get routes for original vpc
+      ec2_vpc_route_table_info:
+        region: us-east-2
+        filters:
+          vpc-id: "{{ original_vpc_id }}"
+      register: original_route_tables
+      tags:
+        - aws-query
+
+    - name: debug VPC route tables
+      debug:
+        msg: "{{ item }}"
+      tags:
+        - aws-query
+      loop: "{{ original_route_tables.route_tables | map(attribute='id')  | list }}"
+
+    - name: create routes in every routing table for original VPC
+      ignore_errors: true  # module not idempotent
+      ec2_vpc_route_table:
+        vpc_id: "{{ original_vpc_id }}"
+        region: us-east-2
+        route_table_id: "{{ item }}"
+        lookup: id
+        purge_routes: no
+        routes:
+          - dest: '10.0.0.0/16'
+            vpc_peering_connection_id: "{{ vpc_peer.peering_id }}"
+      loop: "{{ original_route_tables.route_tables | map(attribute='id')  | list }}"
+      tags:
+        - aws-query
+
+    - name: create routes in every routing table for OpenShift VPC
+      ignore_errors: true  # module not idempotent
+      ec2_vpc_route_table:
+        vpc_id: "{{ openshift_vpc_id }}"
+        region: us-east-2
+        route_table_id: "{{ item }}"
+        lookup: id
+        purge_routes: no
+        routes:
+          - dest: "192.168.0.0/16"
+            vpc_peering_connection_id: "{{ vpc_peer.peering_id }}"
+      loop: "{{ openshift_route_tables.route_tables | map(attribute='id') | list }}"
+      tags:
+        - aws-query
+
+        #######
+        #######
+        # Create AWS Security Groups
+        #######
+        #######
+        #
+    - name: Create AWS Security Groups
+      cloudformation:
+        stack_name: "{{ r_infra_id.stdout }}-sec"
+        template: '~/resources/aws_upi_sec_template.yaml'
+        template_parameters: "{{ lookup('file', HOME ~ '/resources/aws_upi_sec_parameters.json') | from_json | items2dict(key_name='ParameterKey',value_name='ParameterValue') }}"
+      register: r_sec_openshift
+      tags:
+        - aws-query
+
+    - name: Save many variables from SECURITY GROUPS setup
+      shell: >-
+        aws cloudformation describe-stacks --stack-name ${INFRA_ID}-sec --query Stacks[0].Outputs[].[OutputKey,OutputValue] --output text | sed 's_\s_: _g' | tee ~/resources/sec.txt >> ~/resources/cluster_vars.yaml
+      environment:
+        INFRA_ID: "{{ r_infra_id.stdout }}"
+      tags:
+        - aws-query
+
+    - name: Process the templates to generate ~/resources/aws_upi_route53_parameters.json
+      ignore_errors: true
+      shell: >-
+        ansible-playbook ./process.yaml
+      args:
+        chdir: ~/resources/
+      tags:
+        - aws-query
+
+    - name: set bucket_name
+      set_fact:
+        bucket_name: "cluster-{{ guid }}-infra"
+      tags:
+        - aws-query
+
+    - name: make an S3 bucket for Bootstrap ignition files
+      s3_bucket:
+        name: "cluster-{{ guid }}-infra"
+        state: present
+      tags:
+        - aws-query
+
+    - name: copy bootstrap file to bucket
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        src: "{{ HOME }}/aws-upi/bootstrap.ign"
+        object: "/bootstrap.ign"
+        mode: put
+      vars:
+        GUID: "{{ lookup('env', 'GUID') }}"
+        HOME: "{{ lookup('env', 'HOME') }}"
+      tags:
+        - aws-query
+
+        ####
+        ####
+        # create bootstrap instance
+
+    - name: Create AWS Bootstrap Node
+      cloudformation:
+        stack_name: "{{ r_infra_id.stdout }}-bootstrap"
+        template: '~/resources/aws_upi_bootstrap_template.yaml'
+        template_parameters: "{{ lookup('file', HOME ~ '/resources/aws_upi_bootstrap_parameters.json') | from_json | items2dict(key_name='ParameterKey',value_name='ParameterValue') }}"
+      register: r_bootstrap_openshift
+      tags:
+        - aws-query
+
+    - name: Get bootstrap private IP address
+      set_fact:
+        bootstrap_private_ip: "{{ r_bootstrap_openshift.stack_outputs.BootstrapPrivateIp }}"
+      tags:
+        - aws-query
+
+    - name: get certs from master and worker ignition file
+      set_fact:
+        master_cert:
+          "{{ lookup('file', HOME ~ '/aws-upi/master.ign') | from_json |
+          json_query('ignition.security.tls.certificateAuthorities[0].source') }}"
+        worker_cert:
+          "{{ lookup('file', HOME ~ '/aws-upi/worker.ign') | from_json |
+          json_query('ignition.security.tls.certificateAuthorities[0].source') }}"
+
+    - name: update master ignition files with certs
+      lineinfile:
+        path: '$HOME/resources/aws_upi_control_plane_parameters.json'
+        regex: '"ParameterValue": "XXXX"'
+        line: '   "ParameterValue": "{{ master_cert }}"'
+
+    - name: update worker ignition files with certs
+      lineinfile:
+        path: '$HOME/resources/aws_upi_worker_parameters.json'
+        regex: '"ParameterValue": "XXXX"'
+        line: '   "ParameterValue": "{{ worker_cert }}"'
+
+    - name: Create AWS control-plane Nodes
+      cloudformation:
+        stack_name: "{{ r_infra_id.stdout }}-control-plane"
+        template: '~/resources/aws_upi_control_plane_template.yaml'
+        template_parameters: "{{ lookup('file', HOME ~ '/resources/aws_upi_control_plane_parameters.json') | from_json | items2dict(key_name='ParameterKey',value_name='ParameterValue') }}"
+      register: r_control_plane_openshift
+      tags:
+        - aws-query
+
+    - name: Wait 10 minutes for bootstrapping to have a chance at life
+      wait_for:
+        timeout: 600
+
+    - name: Wait for bootstrap complete
+      shell: /usr/local/sbin/openshift-install wait-for bootstrap-complete --dir $HOME/aws-upi
+
+    - name: Delete bootstrap node
+      cloudformation:
+        stack_name: "{{ r_infra_id.stdout }}-bootstrap"
+        state: "absent"
+
+    - name: Set KUBECONFIG env var
+      lineinfile:
+        path: $HOME/.bashrc
+        regexp: "^export KUBECONFIG"
+        line: "export KUBECONFIG=$HOME/aws-upi/auth/kubeconfig"
+
+    - name: Create worker AWS instances
+      cloudformation:
+        stack_name: "{{ r_infra_id.stdout }}-worker-{{ item }}"
+        template: '~/resources/aws_upi_worker_template.yaml'
+        template_parameters: "{{ lookup('file', HOME ~ '/resources/aws_upi_worker_parameters.json') | from_json | items2dict(key_name='ParameterKey',value_name='ParameterValue') }}"
+      loop:
+        - 1
+        - 2
+      register: r_workers_openshift
+      tags:
+        - aws-query
+
+    - name: Get current bootstrap CSRs (10m max)
+      k8s_info:
+        api_version: certificates.k8s.io/v1beta1
+        kind: CertificateSigningRequest
+        validate_certs: false
+      register: r_bootstrap_csr
+      retries: 20
+      delay: 30
+      until:
+      - r_bootstrap_csr.resources is defined
+      - r_bootstrap_csr.resources | length > 0
+      - r_bootstrap_csr.resources | to_json | from_json | json_query(bootstrap_csr_query) | length >= 2
+      vars:
+        bootstrap_csr_query: >-
+          [?!(status) && contains(spec.username, `bootstrap`)] | []
+      environment:
+        KUBECONFIG: "{{ lookup('env', 'HOME') }}/aws-upi/auth/kubeconfig"
+      tags: bootstrap_csr_check
+
+    - name: dump r_bootstrap_csr
+      debug:
+        var: r_bootstrap_csr
+      tags: bootstrap_csr_check
+
+    - name: Approve pending bootstrap CSRs
+      shell: /usr/local/sbin/oc adm certificate approve {{ item }}
+      environment:
+        KUBECONFIG: "{{ lookup('env', 'HOME') }}/aws-upi/auth/kubeconfig"
+      loop: "{{ r_bootstrap_csr.resources | to_json | from_json | json_query(bootstrap_pending_query) }}"
+      vars:
+        bootstrap_pending_query: >-
+          [?!(status) && contains(spec.username, `bootstrap`)].metadata.name
+      tags: bootstrap_csr_check
+
+    - name: Get current node CSRs (10m max)
+      k8s_facts:
+        api_version: certificates.k8s.io/v1beta1
+        kind: CertificateSigningRequest
+        validate_certs: false
+      register: r_node_csr
+      retries: 20
+      delay: 30
+      until: r_node_csr.resources | to_json | from_json | json_query(node_csr_query) | length >= 2
+      vars:
+        node_csr_query: >-
+          [?!(status) && contains(spec.username, `node`)] | []
+      environment:
+        KUBECONFIG: "{{ lookup('env', 'HOME') }}/aws-upi/auth/kubeconfig"
+      tags: node_csr_check
+
+    - name: dump r_node_csr
+      debug:
+        var: r_node_csr
+      tags: node_csr_check
+
+    - name: Approve pending node CSRs
+      shell: /usr/local/sbin/oc adm certificate approve {{ item }}
+      environment:
+        KUBECONFIG: "{{ lookup('env', 'HOME') }}/aws-upi/auth/kubeconfig"
+      loop: "{{ r_node_csr.resources | to_json | from_json | json_query(node_pending_query) }}"
+      vars:
+        node_pending_query: >-
+          [?!(status) && contains(spec.username, 'node')].metadata.name
+      tags: node_csr_check
+
+    - pause:
+        seconds: 15
+
+    - name: Check for two worker nodes
+      shell: /usr/local/sbin/oc get node -l node-role.kubernetes.io/worker --no-headers
+      register: r_nodes
+      environment:
+        KUBECONFIG: "{{ lookup('env', 'HOME') }}/aws-upi/auth/kubeconfig"
+
+    - name: Check for two worker nodes
+      assert:
+        that: r_nodes.stdout_lines | length == 2
+
+#
+## Switch Image Registry from PVC RWO Cinder to PVC RWX NFS
+## WK: No longer necessary when running on Orange
+#
+
+    # - name: Wait until wrong PVC exists as installed by the installer
+    #   environment:
+    #     KUBECONFIG: "{{ lookup('env', 'HOME') }}/aws-upi/auth/kubeconfig"
+    #   k8s_facts:
+    #     kind: PersistentVolumeClaim
+    #     namespace: openshift-image-registry
+    #   register: r_pvcs
+    #   retries: 20
+    #   delay: 30
+    #   until:
+    #   - r_pvcs.resources is defined
+    #   - r_pvcs.resources | length == 1
+    #   tags: test_csv
+
+    # - name: Patch registry to scale to 0
+    #   shell: >-
+    #     oc patch configs.imageregistry.operator.openshift.io cluster --type json --patch
+    #     '[{ "op": "replace", "path": "/spec/replicas", "value": 0}]'
+    #   environment:
+    #     KUBECONFIG: "{{ lookup('env', 'HOME') }}/aws-upi/auth/kubeconfig"
+    #   tags: test_csv
+
+    # - name: Delete registry PVC on cinder
+    #   shell: >-
+    #     oc delete pvc --all -n openshift-image-registry
+    #   environment:
+    #     KUBECONFIG: "{{ lookup('env', 'HOME') }}/aws-upi/auth/kubeconfig"
+
+    # - name: Wait until PVC is gone
+    #   k8s_facts:
+    #     kind: PersistentVolumeClaim
+    #     namespace: openshift-image-registry
+    #   register: r_pvcs
+    #   retries: 20
+    #   delay: 30
+    #   until: r_pvcs.resources | length == 0
+    #   environment:
+    #     KUBECONFIG: "{{ lookup('env', 'HOME') }}/aws-upi/auth/kubeconfig"
+    #   tags: test_csv
+
+    # - name: Create registry PV
+    #   k8s:
+    #     state: present
+    #     src: "{{ lookup('env', 'HOME') }}/resources/pv-registry.yaml"
+    #   environment:
+    #     KUBECONFIG: "{{ lookup('env', 'HOME') }}/aws-upi/auth/kubeconfig"
+    #   tags: test_csv
+
+    # - name: Create registry PVC
+    #   k8s:
+    #     state: present
+    #     src: "$HOME/resources/pvc-registry.yaml"
+    #   environment:
+    #     KUBECONFIG: "{{ lookup('env', 'HOME') }}/aws-upi/auth/kubeconfig"
+    #   tags: test_csv
+
+    # - name: Patch registry to scale to two pods
+    #   shell: >-
+    #     /usr/local/sbin/oc patch configs.imageregistry.operator.openshift.io cluster --type=json -p
+    #     '[{"op": "replace", "path": "/spec/replicas", "value": 2}]'
+    #   environment:
+    #     KUBECONFIG: "{{ lookup('env', 'HOME') }}/aws-upi/auth/kubeconfig"
+    #   tags: test_csv
+
+    - name: Finish installation
+      shell: /usr/local/sbin/openshift-install wait-for install-complete --dir $HOME/aws-upi

--- a/courses/ocp4_advanced_deployment/lab_03_1aws/templates/aws_upi_bootstrap_parameters.json.j2
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/templates/aws_upi_bootstrap_parameters.json.j2
@@ -1,0 +1,51 @@
+[
+  {
+    "ParameterKey": "InfrastructureName",
+    "ParameterValue": "{{ INFRA_ID }}"
+  },
+  {
+    "ParameterKey": "RhcosAmi",
+    "ParameterValue": "ami-0a1f868ad58ea59a7"
+  },
+  {
+    "ParameterKey": "AllowedBootstrapSshCidr",
+    "ParameterValue": "0.0.0.0/0"
+  },
+  {
+    "ParameterKey": "PublicSubnet",
+    "ParameterValue": "{{ PublicSubnetIds }}"
+  },
+  {
+    "ParameterKey": "MasterSecurityGroupId",
+    "ParameterValue": "{{ MasterSecurityGroupId }}"
+  },
+  {
+    "ParameterKey": "VpcId",
+    "ParameterValue": "{{ VpcId }}"
+  },
+  {
+    "ParameterKey": "BootstrapIgnitionLocation",
+    "ParameterValue": "s3://{{ CLUSTER_NAME }}-infra/bootstrap.ign"
+  },
+  {
+    "ParameterKey": "AutoRegisterELB",
+    "ParameterValue": "yes"
+  },
+  {
+    "ParameterKey": "RegisterNlbIpTargetsLambdaArn",
+    "ParameterValue": "{{ RegisterNlbIpTargetsLambda }}"
+  },
+  {
+    "ParameterKey": "ExternalApiTargetGroupArn",
+    "ParameterValue": "{{ ExternalApiTargetGroupArn }}"
+  },
+  {
+    "ParameterKey": "InternalApiTargetGroupArn",
+    "ParameterValue": "{{ InternalApiTargetGroupArn }}"
+  },
+  {
+    "ParameterKey": "InternalServiceTargetGroupArn",
+    "ParameterValue": "{{ InternalServiceTargetGroupArn }}"
+  }
+]
+

--- a/courses/ocp4_advanced_deployment/lab_03_1aws/templates/aws_upi_control_plane_parameters.json.j2
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/templates/aws_upi_control_plane_parameters.json.j2
@@ -1,0 +1,74 @@
+[
+  {
+    "ParameterKey": "InfrastructureName",
+    "ParameterValue": "{{ INFRA_ID }}"
+  },
+  {
+    "ParameterKey": "RhcosAmi",
+    "ParameterValue": "ami-0a1f868ad58ea59a7"
+  },
+  {
+    "ParameterKey": "AutoRegisterDNS",
+    "ParameterValue": "yes"
+  },
+  {
+    "ParameterKey": "PrivateHostedZoneId",
+    "ParameterValue": "{{ PrivateHostedZoneId }}"
+  },
+  {
+    "ParameterKey": "PrivateHostedZoneName",
+    "ParameterValue": "{{ CLUSTER_NAME }}.{{ BASE_DOMAIN }}"
+  },
+  {
+    "ParameterKey": "Master0Subnet",
+    "ParameterValue": "{{ PrivateSubnetIds }}"
+  },
+  {
+    "ParameterKey": "Master1Subnet",
+    "ParameterValue": "{{ PrivateSubnetIds }}"
+  },
+  {
+    "ParameterKey": "Master2Subnet",
+    "ParameterValue": "{{ PrivateSubnetIds }}"
+  },
+  {
+    "ParameterKey": "MasterSecurityGroupId",
+    "ParameterValue": "{{ MasterSecurityGroupId }}"
+  },
+  {
+    "ParameterKey": "IgnitionLocation",
+    "ParameterValue": "https://api-int.{{ CLUSTER_NAME }}.{{ BASE_DOMAIN }}:22623/config/master"
+  },
+  {
+    "ParameterKey": "CertificateAuthorities",
+    "ParameterValue": "XXXX"
+  },
+  {
+    "ParameterKey": "MasterInstanceProfileName",
+    "ParameterValue": "{{ MasterInstanceProfile }}"
+  },
+  {
+    "ParameterKey": "MasterInstanceType",
+    "ParameterValue": "m5.xlarge"
+  },
+  {
+    "ParameterKey": "AutoRegisterELB",
+    "ParameterValue": "yes"
+  },
+  {
+    "ParameterKey": "RegisterNlbIpTargetsLambdaArn",
+    "ParameterValue": "{{ RegisterNlbIpTargetsLambda }}"
+  },
+  {
+    "ParameterKey": "ExternalApiTargetGroupArn",
+    "ParameterValue": "{{ ExternalApiTargetGroupArn }}"
+  },
+  {
+    "ParameterKey": "InternalApiTargetGroupArn",
+    "ParameterValue": "{{ InternalApiTargetGroupArn }}"
+  },
+  {
+    "ParameterKey": "InternalServiceTargetGroupArn",
+    "ParameterValue": "{{ InternalServiceTargetGroupArn }}"
+  }
+]

--- a/courses/ocp4_advanced_deployment/lab_03_1aws/templates/aws_upi_route53_parameters.json.j2
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/templates/aws_upi_route53_parameters.json.j2
@@ -1,0 +1,30 @@
+[
+  {
+    "ParameterKey": "ClusterName",
+    "ParameterValue": "{{ CLUSTER_NAME }}"
+  },
+  {
+    "ParameterKey": "InfrastructureName",
+    "ParameterValue": "{{ INFRA_ID }}"
+  },
+  {
+    "ParameterKey": "HostedZoneId",
+    "ParameterValue": "{{ HostedZoneId }}"
+  },
+  {
+    "ParameterKey": "HostedZoneName",
+    "ParameterValue": "{{ BASE_DOMAIN }}"
+  },
+  {
+    "ParameterKey": "PublicSubnets",
+    "ParameterValue": "{{ PublicSubnetIds }}"
+  },
+  {
+    "ParameterKey": "PrivateSubnets",
+    "ParameterValue": "{{ PrivateSubnetIds }}"
+  },
+  {
+    "ParameterKey": "VpcId",
+    "ParameterValue": "{{ VpcId }}"
+  }
+]

--- a/courses/ocp4_advanced_deployment/lab_03_1aws/templates/aws_upi_sec_parameters.json.j2
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/templates/aws_upi_sec_parameters.json.j2
@@ -1,0 +1,18 @@
+[
+  {
+    "ParameterKey": "InfrastructureName",
+    "ParameterValue": "{{ INFRA_ID }}"
+  },
+  {
+    "ParameterKey": "VpcCidr",
+    "ParameterValue": "10.0.0.0/16"
+  },
+  {
+    "ParameterKey": "PrivateSubnets",
+    "ParameterValue": "{{ PrivateSubnetIds }}"
+  },
+  {
+    "ParameterKey": "VpcId",
+    "ParameterValue": "{{ VpcId }}"
+  }
+]

--- a/courses/ocp4_advanced_deployment/lab_03_1aws/templates/aws_upi_worker_parameters.json.j2
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/templates/aws_upi_worker_parameters.json.j2
@@ -1,0 +1,34 @@
+[
+  {
+    "ParameterKey": "InfrastructureName",
+    "ParameterValue": "{{ INFRA_ID }}"
+  },
+  {
+    "ParameterKey": "RhcosAmi",
+    "ParameterValue": "ami-0a1f868ad58ea59a7"
+  },
+  {
+    "ParameterKey": "Subnet",
+    "ParameterValue": "{{ PrivateSubnetIds }}"
+  },
+  {
+    "ParameterKey": "WorkerSecurityGroupId",
+    "ParameterValue": "{{ WorkerSecurityGroupId }}"
+  },
+  {
+    "ParameterKey": "IgnitionLocation",
+    "ParameterValue": "https://api-int.{{ CLUSTER_NAME }}.{{ BASE_DOMAIN }}:22623/config/worker"
+  },
+  {
+    "ParameterKey": "CertificateAuthorities",
+    "ParameterValue": "XXXX"
+  },
+  {
+    "ParameterKey": "WorkerInstanceProfileName",
+    "ParameterValue": "{{ WorkerInstanceProfile }}"
+  },
+  {
+    "ParameterKey": "WorkerInstanceType",
+    "ParameterValue": "m5.xlarge"
+  }
+]

--- a/courses/ocp4_advanced_deployment/lab_03_1aws/templates/ca-config.json.j2
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/templates/ca-config.json.j2
@@ -1,0 +1,25 @@
+{
+    "signing": {
+        "default": {
+            "expiry": "87600h"
+        },
+        "profiles": {
+            "server": {
+                "expiry": "87600h",
+                "usages": [
+                    "signing",
+                    "key encipherment",
+                    "server auth"
+                ]
+            },
+            "client": {
+                "expiry": "87600h",
+                "usages": [
+                    "signing",
+                    "key encipherment",
+                    "client auth"
+                ]
+            }
+        }
+    }
+}

--- a/courses/ocp4_advanced_deployment/lab_03_1aws/templates/ca-csr.json.j2
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/templates/ca-csr.json.j2
@@ -1,0 +1,18 @@
+{
+    "CN": "Red Hat GPTE",
+    "hosts": [
+        "utilityvm.{{ guid }}.internal"
+    ],
+    "key": {
+        "algo": "rsa",
+        "size": 2048
+    },
+    "names": [
+        {
+            "C": "US",
+            "ST": "Washington",
+            "L": "Seattle",
+            "OU": "GPTE"
+        }
+    ]
+}

--- a/courses/ocp4_advanced_deployment/lab_03_1aws/templates/install-config.yaml.j2
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/templates/install-config.yaml.j2
@@ -1,0 +1,40 @@
+apiVersion: v1
+baseDomain: {{ sandbox_hosted_zone_name }}
+compute:
+- hyperthreading: Enabled
+  name: worker
+  platform: {}
+  replicas: 0
+controlPlane:
+  hyperthreading: Enabled
+  name: master
+  platform: 
+    aws:
+      type: m5.xlarge
+  replicas: 3
+metadata:
+  name: cluster-{{ lookup('env', 'GUID') }}
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineCIDR: 192.168.47.0/24
+  networkType: OpenShiftSDN
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  aws:
+    region: us-east-2
+publish: External
+pullSecret: '{{ lookup('file', HOME ~ '/merged_pullsecret.json') }}'
+sshKey: |
+  {{ lookup('file', HOME ~ '/.ssh/' ~ GUID ~ 'key.pub') | indent(2, true) }}
+imageContentSources:
+- mirrors:
+  - utilityvm.example.com:5000/ocp4/openshift4
+  source: quay.io/openshift-release-dev/ocp-release
+- mirrors:
+  - utilityvm.example.com:5000/ocp4/openshift4
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+additionalTrustBundle: |
+  {{ lookup('file', '/etc/pki/ca-trust/source/anchors/ca.pem') | indent(2, false) }}

--- a/courses/ocp4_advanced_deployment/lab_03_1aws/templates/server.json.j2
+++ b/courses/ocp4_advanced_deployment/lab_03_1aws/templates/server.json.j2
@@ -1,0 +1,18 @@
+{
+    "CN": "Red Hat GPTE",
+    "hosts": [
+        "utilityvm.{{ guid }}.internal"
+    ],
+    "key": {
+        "algo": "ecdsa",
+        "size": 256
+    },
+    "names": [
+        {
+            "C": "US",
+            "ST": "Washington",
+            "L": "Seattle",
+            "OU": "GPTE"
+        }
+    ]
+}


### PR DESCRIPTION
new lab dir under ocp4_advanced_deployment: lab_03_1aws

Runs like the old one did:

* Solver first resets and then solves

Changes:
* reset runs `openshift-install destroy cluster --dir ~/aws-upi` AND deletes all the cloudformation stacks in ASYNC so they can handle race conditions.
* solver only runs resetter if there's an ~/aws-upi/metadata.json to work from
* OMG, so many changes for AWS.  Kind of a night mare.